### PR TITLE
Move stage2 to images/install.img (#815275)

### DIFF
--- a/share/aarch64.tmpl
+++ b/share/aarch64.tmpl
@@ -3,13 +3,13 @@
 configdir="tmp/config_files/aarch64"
 PXEBOOTDIR="images/pxeboot"
 KERNELDIR=PXEBOOTDIR
-LIVEDIR="LiveOS"
+STAGE2IMG="images/install.img"
 LORAXDIR="usr/share/lorax/"
 %>
 
-mkdir ${LIVEDIR}
-install ${runtime_img} ${LIVEDIR}/squashfs.img
-treeinfo stage2 mainimage ${LIVEDIR}/squashfs.img
+mkdir images
+install ${runtime_img} ${STAGE2IMG}
+treeinfo stage2 mainimage ${STAGE2IMG}
 
 ## install kernels
 mkdir ${KERNELDIR}
@@ -52,7 +52,7 @@ mkdir ${KERNELDIR}
 runcmd mkisofs -o ${outroot}/images/boot.iso \
        ${efiargs} -R -J -V '${isolabel}' -T -graft-points \
        ${KERNELDIR}=${outroot}/${KERNELDIR} \
-       ${LIVEDIR}=${outroot}/${LIVEDIR} \
+       ${STAGE2IMG}=${outroot}/${STAGE2IMG} \
        ${efigraft} ${imggraft}
 treeinfo images-${basearch} boot.iso images/boot.iso
 %endif

--- a/share/arm.tmpl
+++ b/share/arm.tmpl
@@ -5,7 +5,7 @@ PXEBOOTDIR="images/pxeboot"
 DTBDIR="images/pxeboot/dtb"
 BOOTDIR="boot"
 KERNELDIR=PXEBOOTDIR
-LIVEDIR="LiveOS"
+STAGE2IMG="images/install.img"
 LORAXDIR="usr/share/lorax/"
 
 # different platforms use different kernel load addresses.
@@ -19,9 +19,9 @@ platforms = ""
 delimiter = ''
 %>
 
-mkdir ${LIVEDIR}
-install ${runtime_img} ${LIVEDIR}/squashfs.img
-treeinfo stage2 mainimage ${LIVEDIR}/squashfs.img
+mkdir images
+install ${runtime_img} ${STAGE2IMG}
+treeinfo stage2 mainimage ${STAGE2IMG}
 
 mkdir ${DTBDIR}
 install boot/dtb-*/*dtb  ${DTBDIR}/

--- a/share/ppc.tmpl
+++ b/share/ppc.tmpl
@@ -3,7 +3,7 @@
 configdir="tmp/config_files/ppc"
 BOOTDIR="ppc"
 GRUBDIR="boot/grub"
-LIVEDIR="LiveOS"
+STAGE2IMG="images/install.img"
 MACDIR=GRUBDIR+"/powerpc-ieee1275"
 NETBOOTDIR="images/netboot"
 LORAXDIR="usr/share/lorax/"
@@ -23,9 +23,9 @@ isolabel = ''.join(ch if ch.isalnum() else '_' for ch in isolabel)
 rootarg = ""
 %>
 
-mkdir ${LIVEDIR}
-install ${runtime_img} ${LIVEDIR}/squashfs.img
-treeinfo stage2 mainimage ${LIVEDIR}/squashfs.img
+mkdir images
+install ${runtime_img} ${STAGE2IMG}
+treeinfo stage2 mainimage ${STAGE2IMG}
 
 ## install bootloaders.
 ## NOTE: there's two different bootloader setups here:
@@ -107,7 +107,7 @@ runcmd mkisofs -o ${outroot}/images/boot.iso -chrp-boot -U \
         ${BOOTDIR}=${outroot}/${BOOTDIR} \
         ${GRUBDIR}=${outroot}/${GRUBDIR} \
         ${NETBOOTDIR}=${outroot}/${NETBOOTDIR} \
-        ${LIVEDIR}=${outroot}/${LIVEDIR} ${imggraft}
+        ${STAGE2IMG}=${outroot}/${STAGE2IMG} ${imggraft}
 
 
 %for kernel in kernels:

--- a/share/ppc64le.tmpl
+++ b/share/ppc64le.tmpl
@@ -3,7 +3,7 @@
 configdir="tmp/config_files/ppc"
 BOOTDIR="ppc"
 GRUBDIR="boot/grub"
-LIVEDIR="LiveOS"
+STAGE2IMG="images/install.img"
 LORAXDIR="usr/share/lorax/"
 
 ## NOTE: yaboot freaks out and stops parsing its config if it sees a '\',
@@ -16,9 +16,9 @@ isolabel = ''.join(ch if ch.isalnum() else '_' for ch in isolabel)
 rootarg = ""
 %>
 
-mkdir ${LIVEDIR}
-install ${runtime_img} ${LIVEDIR}/squashfs.img
-treeinfo stage2 mainimage ${LIVEDIR}/squashfs.img
+mkdir images
+install ${runtime_img} ${STAGE2IMG}
+treeinfo stage2 mainimage ${STAGE2IMG}
 
 ## install the bootloaders
 ##   ppc/chrp: for normal PPC systems.
@@ -83,7 +83,7 @@ runcmd mkisofs -v -U -J -R -T \
         -no-desktop -allow-multidot -graft-points \
         ${BOOTDIR}=${outroot}/${BOOTDIR} \
         ${GRUBDIR}=${outroot}/${GRUBDIR} \
-        ${LIVEDIR}=${outroot}/${LIVEDIR} ${imggraft}
+        ${STAGE2IMG}=${outroot}/${STAGE2IMG} ${imggraft}
 
 %for kernel in kernels:
     treeinfo images-${kernel.arch} boot.iso images/boot.iso

--- a/share/x86.tmpl
+++ b/share/x86.tmpl
@@ -1,11 +1,11 @@
-<%page args="kernels, runtime_img, basearch, outroot, product, isolabel"/>
+<%page args="kernels, runtime_img, runtime_base, basearch, outroot, product, isolabel"/>
 <%
 configdir="tmp/config_files/x86"
 SYSLINUXDIR="usr/share/syslinux"
 PXEBOOTDIR="images/pxeboot"
+STAGE2IMG="images/install.img"
 BOOTDIR="isolinux"
 KERNELDIR=PXEBOOTDIR
-LIVEDIR="LiveOS"
 LORAXDIR="usr/share/lorax/"
 
 ## Don't allow spaces or escape characters in the iso label
@@ -15,9 +15,9 @@ def valid_label(ch):
 isolabel = ''.join(ch if valid_label(ch) else '-' for ch in isolabel)
 %>
 
-mkdir ${LIVEDIR}
-install ${runtime_img} ${LIVEDIR}/squashfs.img
-treeinfo stage2 mainimage ${LIVEDIR}/squashfs.img
+mkdir images
+install ${runtime_img} ${STAGE2IMG}
+treeinfo stage2 mainimage images/${runtime_base}
 
 ## install bootloader and config files
 mkdir ${BOOTDIR}
@@ -102,9 +102,9 @@ runcmd mkisofs -o ${outroot}/images/boot.iso \
        -b ${BOOTDIR}/isolinux.bin -c ${BOOTDIR}/boot.cat \
        -boot-load-size 4 -boot-info-table -no-emul-boot \
        ${efiargs} -R -J -V '${isolabel}' -T -graft-points \
+       ${STAGE2IMG}=${outroot}/${STAGE2IMG} \
        ${BOOTDIR}=${outroot}/${BOOTDIR} \
        ${KERNELDIR}=${outroot}/${KERNELDIR} \
-       ${LIVEDIR}=${outroot}/${LIVEDIR} \
        ${efigraft} ${imggraft}
 runcmd isohybrid ${efihybrid} ${outroot}/images/boot.iso
 treeinfo images-${basearch} boot.iso images/boot.iso


### PR DESCRIPTION
Use the same stage2 location for all arches, put it in images with all
the other images. This only effects boot.iso, live images still use
LiveOS/squashfs.img because that's where dracut's 90dmsquashfs-live
module expects to find it.

For boot.iso anaconda-dracut handles finding stage2, looking at
images/install.img and LiveOS/squashfs.img