### PR TITLE
Turn off ldconfig

### DIFF
--- a/share/runtime-postinstall.tmpl
+++ b/share/runtime-postinstall.tmpl
@@ -41,7 +41,8 @@ systemctl disable systemd-readahead-collect.service \
 ## /usr/lib/systemd rather than /etc/systemd), so we have to mask them.
 systemctl mask fedora-configure.service fedora-loadmodules.service \
                fedora-autorelabel.service fedora-autorelabel-mark.service \
-               fedora-wait-storage.service media.mount
+               fedora-wait-storage.service media.mount \
+               ldconfig.service
 
 ## Make logind activate anaconda-shell@.service on switch to empty VT
 symlink anaconda-shell@.service lib/systemd/system/autovt@.service


### PR DESCRIPTION
We don't need to update ldconfig when running the boot.iso, disable it
to speed up the boot.