### PR TITLE
Don't erase /usr/lib/os.release.d

### DIFF
--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -27,7 +27,8 @@ removefrom dracut --allbut /usr/lib/dracut/modules.d/30convertfs/convertfs.sh \
 ## we don't run SELinux (not in enforcing, anyway)
 removepkg checkpolicy selinux-policy libselinux-utils
 ## anaconda has its own repo files
-removefrom fedora-release --allbut /etc/os-release /usr/lib/os-release
+removefrom fedora-release --allbut /etc/os-release /usr/lib/os-release \
+                                   /usr/lib/os.release.d/*
 removepkg fedora-release-rawhide
 ## no user accounts = no account management
 removepkg usermode usermode-gtk passwd shadow-utils


### PR DESCRIPTION
This directory now contains the standard and productized
/etc/os-release feeder files.