### PR TITLE
Turn off ldconfig (#1204031)

### DIFF
--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -191,7 +191,7 @@ removefrom gdisk /usr/share/*
 removefrom gdk-pixbuf2 /usr/share/locale*
 removefrom gfs2-utils /usr/sbin/*
 removefrom glib2 /etc/* /usr/bin/* /usr/share/locale/*
-removefrom glibc /etc/gai.conf /etc/ld.so.conf /etc/localtime /etc/rpc
+removefrom glibc /etc/gai.conf /etc/localtime /etc/rpc
 removefrom glibc /lib/*/nosegneg/* /${libdir}/libBrokenLocale*
 removefrom glibc /${libdir}/libSegFault* /${libdir}/libanl*
 removefrom glibc /${libdir}/libcidn* /${libdir}/libnss_compat*


### PR DESCRIPTION
We don't need to update ldconfig when running the boot.iso, disable it
to speed up the boot.

(cherry picked from commit c4c90e0b5ee1f3684cd4beed4f0b935570f897b1)