### PR TITLE
Add ability for external templates to graft content into boot.iso

### DIFF
--- a/share/aarch64.tmpl
+++ b/share/aarch64.tmpl
@@ -47,6 +47,13 @@ mkdir ${KERNELDIR}
     %endif
 %endfor
 
+# Inherit iso-graft/ if it exists from external templates
+<%
+    import os
+    if os.path.exists(workdir + "/iso-graft"):
+        imggraft += " " + workdir + "/iso-graft"
+%>
+
 %if exists("boot/efi/EFI/*/gcdaa64.efi"):
 ## make boot.iso
 runcmd mkisofs -o ${outroot}/images/boot.iso \

--- a/share/arm.tmpl
+++ b/share/arm.tmpl
@@ -123,5 +123,12 @@ treeinfo ${basearch} platforms ${platforms}
     %endif
 %endfor
 
+# Inherit iso-graft/ if it exists from external templates
+<%
+    import os
+    if os.path.exists(workdir + "/iso-graft"):
+        imggraft += " " + workdir + "/iso-graft"
+%>
+
 ## FIXME: ARM may need some extra boot config
 

--- a/share/ppc.tmpl
+++ b/share/ppc.tmpl
@@ -96,6 +96,13 @@ install ${configdir}/mapping ${BOOTDIR}
     %endif
 %endfor
 
+# Inherit iso-graft/ if it exists from external templates
+<%
+    import os
+    if os.path.exists(workdir + "/iso-graft"):
+        imggraft += " " + workdir + "/iso-graft"
+%>
+
 ## make boot.iso
 runcmd mkisofs -o ${outroot}/images/boot.iso -chrp-boot -U \
         ${prepboot} -part -hfs -T -r -l -J \

--- a/share/ppc64le.tmpl
+++ b/share/ppc64le.tmpl
@@ -72,6 +72,13 @@ mkdir images/
     %endif
 %endfor
 
+# Inherit iso-graft/ if it exists from external templates
+<%
+    import os
+    if os.path.exists(workdir + "/iso-graft"):
+        imggraft += " " + workdir + "/iso-graft"
+%>
+
 ## make boot.iso
 runcmd mkisofs -v -U -J -R -T \
         -o ${outroot}/images/boot.iso \

--- a/share/x86.tmpl
+++ b/share/x86.tmpl
@@ -97,6 +97,13 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
     %endif
 %endfor
 
+# Inherit iso-graft/ if it exists from external templates
+<%
+    import os
+    if os.path.exists(workdir + "/iso-graft"):
+        imggraft += " " + workdir + "/iso-graft"
+%>
+
 ## make boot.iso
 runcmd mkisofs -o ${outroot}/images/boot.iso \
        -b ${BOOTDIR}/isolinux.bin -c ${BOOTDIR}/boot.cat \

--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -155,7 +155,10 @@ class Lorax(BaseLoraxClass):
             installpkgs=None,
             size=2,
             add_templates=None,
-            add_template_vars=None):
+            add_template_vars=None,
+            add_arch_templates=None,
+            add_arch_template_vars=None,
+            template_tempdir=None):
 
         assert self._configured
 
@@ -312,7 +315,10 @@ class Lorax(BaseLoraxClass):
                                   inroot=installroot, outroot=self.outputdir,
                                   runtime=runtime, isolabel=isolabel,
                                   domacboot=domacboot, doupgrade=doupgrade,
-                                  templatedir=templatedir)
+                                  templatedir=templatedir,
+                                  add_templates=add_arch_templates,
+                                  add_template_vars=add_arch_template_vars,
+                                  workdir=self.workdir)
 
         logger.info("rebuilding initramfs images")
         dracut_args = ["--xz", "--install", "/.buildstamp"]

--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -175,7 +175,7 @@ class LoraxTemplateRunner(object):
     def run(self, templatefile, **variables):
         for k,v in self.defaults.items() + self.builtins.items():
             variables.setdefault(k,v)
-        logger.debug("parsing %s", templatefile)
+        logger.debug("executing {0} with variables={1}".format(templatefile, variables))
         self.templatefile = templatefile
         t = LoraxTemplate(directories=[self.templatedir])
         commands = t.parse(templatefile, variables)

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -137,11 +137,17 @@ def main(args):
     optional.add_option("--tmp", default="/var/tmp",
             help="Top level temporary directory" )
     optional.add_option("--add-template", dest="add_templates",
-            action="append", help="Additional template to execute",
-            default=[])
+                        action="append", help="Additional template for runtime image",
+                        default=[])
     optional.add_option("--add-template-var", dest="add_template_vars",
-            action="append", help="Set variable for additional templates",
-            default=[])
+                        action="append", help="Set variable for runtime image template",
+                        default=[])
+    optional.add_option("--add-arch-template", dest="add_arch_templates",
+                        action="append", help="Additional template for architecture-specific image",
+                        default=[])
+    optional.add_option("--add-arch-template-var", dest="add_arch_template_vars",
+                        action="append", help="Set variable for architecture-specific image",
+                        default=[])
 
     # add the option groups to the parser
     parser.add_option_group(required)
@@ -201,6 +207,13 @@ def main(args):
             raise ValueError("Missing '=' for key=value in " % kv)
         parsed_add_template_vars[k] = v
 
+    parsed_add_arch_template_vars = {}
+    for kv in opts.add_arch_template_vars:
+        k, t, v = kv.partition('=')
+        if t == '':
+            raise ValueError("Missing '=' for key=value in " % kv)
+        parsed_add_arch_template_vars[k] = v
+
     # run lorax
     lorax = pylorax.Lorax()
     lorax.configure(conf_file=opts.config)
@@ -211,6 +224,8 @@ def main(args):
               installpkgs=opts.installpkgs,
               add_templates=opts.add_templates,
               add_template_vars=parsed_add_template_vars,
+              add_arch_templates=opts.add_arch_templates,
+              add_arch_template_vars=parsed_add_arch_template_vars,
               remove_temp=True)
 
 


### PR DESCRIPTION
I originally added --add-template to support doing something similar
to pungi, which injects content into the system to be used by default.
However, this causes the content to be part of the squashfs, which
means PXE installations have to download significantly more data that
they may not need (if they actually want to pull the tree data from
the network, which is not an unusual case).

What I actually need is to be able to modify *both* the runtime image
and the arch-specific content.  For the runtime, I need to change
/usr/share/anaconda/interactive-defaults.ks to point to the new
content.  (Although, potentially we could patch Anaconda itself to
auto-detect an ostree repository configured in disk image, similar to
what it does for yum repositories)

For the arch-specfic image, I want to drop my content into the ISO
root.

So this patch adds --add-arch-template and --add-arch-template-var
in order to do the latter, while preserving the --add-template
to affect the runtime image.

Further, the templates will automatically graft in a directory named
"iso-graft/" from the working directory (if it exists).

(I suggest that external templates create a subdirectory named
 "content" to avoid clashes with any future lorax work)

Thus, this will be used by the Atomic Host lorax templates to inject
content/repo, but could be used by e.g. pungi to add content/rpms as
well.

I tried to avoid code deduplication by creating a new template for the
product.img bits and this, but that broke because the parent boot.iso
code needs access to the `${imggraft}` variable.  I think a real fix
here would involve turning the product.img, content/, *and* boot.iso
into a new template.

Conflicts:
	src/sbin/lorax