### PR TITLE
Include cryptsetup in the image (#1208214)

### DIFF
--- a/share/runtime-install.tmpl
+++ b/share/runtime-install.tmpl
@@ -56,6 +56,8 @@ installpkg fedup-dracut fedup-dracut-plymouth
 ## install other fedup scripts, if there are any. It's OK if there aren't.
 log "Looking for extra fedup-dracut packages..."
 -installpkg *-fedup-dracut
+## fedup and rescue need this
+installpkg cryptsetup
 
 ## rpcbind or portmap needed by dracut nfs module
 installpkg rpcbind


### PR DESCRIPTION
blivet dropped its requirement on cryptsetup, but fedup needs it in the
upgrade.img and it is useful for rescue mode so add it back.