### PR TITLE
Make sure openssh-clients is installed (#1219398)

### DIFF
--- a/share/runtime-install.tmpl
+++ b/share/runtime-install.tmpl
@@ -98,7 +98,7 @@ installpkg python-nss
 installpkg selinux-policy-targeted audit libsemanage-python
 
 ## network tools/servers
-installpkg python-ethtool ethtool openssh-server nfs-utils
+installpkg python-ethtool ethtool openssh-server nfs-utils openssh-clients
 installpkg tigervnc-server-minimal
 %if basearch != "s390x":
 installpkg tigervnc-server-module


### PR DESCRIPTION
It used to be pulled in by a dependency, which went away. It should be
explicitly installed.