### PR TITLE
Use imgutils.copytree instead of shutil (#1221878)

### DIFF
--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -56,7 +56,7 @@ from pylorax.treebuilder import findkernels
 from pylorax.sysutils import joinpaths, remove
 from pylorax.imgutils import PartitionMount, mksparse, mkext4img, loop_detach
 from pylorax.imgutils import get_loop_name, dm_detach, mount, umount, Mount
-from pylorax.imgutils import mksquashfs, mkqcow2, mktar, mkrootfsimg
+from pylorax.imgutils import mksquashfs, mkqcow2, mktar, mkrootfsimg, copytree
 from pylorax.executils import execWithRedirect, execWithCapture, runcmd
 
 # no-virt mode doesn't need libvirt, so make it optional
@@ -693,7 +693,7 @@ def make_livecd(opts, mount_dir, work_dir):
     fullpath = joinpaths(mount_dir, configdir_path)
     if os.path.exists(fullpath):
         remove(fullpath)
-    shutil.copytree(configdir, fullpath)
+    copytree(configdir, fullpath)
 
     isolabel = opts.volid or "{0.name}-{0.version}-{1.basearch}".format(product, arch)
     if len(isolabel) > 32:
@@ -1480,7 +1480,7 @@ def main():
                                 umount(mounted_sysroot_boot_dir)
 
         if opts.result_dir != opts.tmp and result_dir:
-            shutil.copytree(result_dir, opts.result_dir)
+            copytree(result_dir, opts.result_dir)
             shutil.rmtree(result_dir)
 
     log.info("SUMMARY")


### PR DESCRIPTION
Sometimes the directory is already there, we just want to copy things
into it, so use our copytree.