### PR TITLE
Explicitly add kernel-modules and kernel-modules-extra

### DIFF
--- a/share/runtime-install.tmpl
+++ b/share/runtime-install.tmpl
@@ -13,7 +13,9 @@ installpkg rpm-ostree
 installpkg pigz
 
 ## kernel and firmware
-installpkg kernel
+## NOTE: Without explicitly including kernel-modules-extra dnf will choose kernel-debuginfo-*
+##       to satify a gfs2-utils kmod requirement
+installpkg kernel kernel-modules kernel-modules-extra
 installpkg grubby
 %if basearch != "s390x":
     installpkg *-firmware


### PR DESCRIPTION
When it is left up to dnf to decide how to fulfill the kmod()
requirement from gfs2-utils it will pick kernel-debuginfo-* which adds
about 100M to the size of the iso.

Adding these packages first makes dnf choose them and the iso size is
back down around 450MB