### PR TITLE
Add a bit more overhead to the root filesystem size

### DIFF
--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -248,7 +248,7 @@ def round_to_blocks(size, blocksize):
     return size
 
 # TODO: move filesystem data outside this function
-def estimate_size(rootdir, graft=None, fstype=None, blocksize=4096, overhead=128):
+def estimate_size(rootdir, graft=None, fstype=None, blocksize=4096, overhead=256):
     graft = graft or {}
     getsize = lambda f: os.lstat(f).st_size
     if fstype == "btrfs":


### PR DESCRIPTION
When this is too small the rootfs can run into problems when used with a
live system. Doubling it leaves enough space for the system to run
properly during the installation and since it's all compresses it
doesn't make the image noticeably bigger.