### PR TITLE
Create an empty selinux config file (#1243168)

### DIFF
--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -26,6 +26,11 @@ removefrom dracut --allbut /usr/lib/dracut/modules.d/30convertfs/convertfs.sh \
                   /usr/lib/dracut/dracut-initramfs-restore
 ## we don't run SELinux (not in enforcing, anyway)
 removepkg checkpolicy selinux-policy libselinux-utils
+
+## selinux checks for the /etc/selinux/config file's existance
+## The removepkg above removes it, create an empty one. See rhbz#1243168
+append etc/selinux/config ""
+
 ## anaconda has its own repo files
 removefrom fedora-release --allbut /etc/os-release /usr/lib/os-release \
                                    /usr/lib/os.release.d/*

--- a/share/runtime-postinstall.tmpl
+++ b/share/runtime-postinstall.tmpl
@@ -61,9 +61,6 @@ install ${configdir}/sysctl.conf etc/sysctl.d/anaconda.conf
 install ${configdir}/spice-vdagentd etc/sysconfig
 mkdir etc/NetworkManager/conf.d
 install ${configdir}/91-anaconda-autoconnect-slaves.conf etc/NetworkManager/conf.d
-%if exists(root+"/etc/selinux/targeted"):
-    install ${configdir}/selinux.config etc/selinux/config
-%endif
 
 ## set up sshd
 install ${configdir}/sshd_config.anaconda etc/ssh


### PR DESCRIPTION
In order for selinux to properly label the system it needs to see that
the config file exists.

Also remove the old code trying to copy in a selinux config file, it
never worked -- the removepkg would remove it.