### PR TITLE
verify that everything in /usr/bin and /usr/sbin is still runnable after cleanup

### DIFF
--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -10,7 +10,8 @@ remove usr/share/i18n
     removepkg perl*
 %endif
 ## no sound support, thanks
-removepkg alsa* flac gstreamer-tools libsndfile pulseaudio* sound-theme-freedesktop
+## ...except alsa-libs, which are needed by spice-vdagent
+removepkg alsa-*firmware* flac gstreamer-tools libsndfile pulseaudio* sound-theme-freedesktop
 removepkg midisport-firmware
 ## no fancy video, either
 removepkg libcrystalhd crystalhd-firmware ivtv-firmware cx18-firmware

--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -48,6 +48,10 @@ remove /etc/logrotate.d
 ## anaconda needs this to do media check
 removefrom isomd5sum --allbut /usr/bin/checkisomd5
 
+## systemd-nspawn isn't very useful and doesn't link anyway without iptables,
+## and there's no need for a bunch of zsh files without zsh
+removefrom systemd /usr/bin/systemd-nspawn /usr/share/zsh
+
 ## various other things we remove to save space
 removepkg avahi-autoipd coreutils-libs dash db4-utils diffutils file
 removepkg genisoimage info iptables
@@ -130,7 +134,7 @@ removefrom bind-utils /usr/bin/dig /usr/bin/host /usr/bin/nsupdate
 removefrom bitmap-fangsongti-fonts /usr/share/fonts/*
 removefrom ca-certificates /etc/pki/java/*
 removefrom ca-certificates /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/*
-removefrom cairo /usr/${libdir}/libcairo-script*
+removefrom cairo /usr/${libdir}/libcairo-script* /usr/bin/cairo-sphinx
 removefrom coreutils /etc/* /usr/bin/link /usr/bin/nice /usr/bin/stty /usr/bin/su /usr/bin/unlink
 removefrom coreutils /usr/sbin/runuser /usr/bin/[ /usr/bin/base64 /usr/bin/chcon
 removefrom coreutils /usr/bin/cksum /usr/bin/comm /usr/bin/csplit

--- a/share/runtime-postinstall.tmpl
+++ b/share/runtime-postinstall.tmpl
@@ -41,7 +41,8 @@ systemctl disable systemd-readahead-collect.service \
 systemctl mask fedora-configure.service fedora-loadmodules.service \
                fedora-autorelabel.service fedora-autorelabel-mark.service \
                fedora-wait-storage.service media.mount \
-               systemd-tmpfiles-clean.service systemd-tmpfiles-clean.timer
+               systemd-tmpfiles-clean.service systemd-tmpfiles-clean.timer \
+               ldconfig.service
 
 ## Make logind activate anaconda-shell@.service on switch to empty VT
 symlink anaconda-shell@.service lib/systemd/system/autovt@.service

--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -156,7 +156,8 @@ class Lorax(BaseLoraxClass):
             add_templates=None,
             add_template_vars=None,
             add_arch_templates=None,
-            add_arch_template_vars=None):
+            add_arch_template_vars=None,
+            verify=True):
 
         assert self._configured
 
@@ -288,6 +289,13 @@ class Lorax(BaseLoraxClass):
 
         logger.info("cleaning unneeded files")
         rb.cleanup()
+
+        if verify:
+            logger.info("verifying the installroot")
+            if not rb.verify():
+                sys.exit(1)
+        else:
+            logger.info("Skipping verify")
 
         if self.debug:
             rb.writepkgsizes(joinpaths(logdir, "final-pkgsizes.txt"))

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -114,6 +114,8 @@ def main(args):
     optional.add_argument("--add-arch-template-var", dest="add_arch_template_vars",
                         action="append", help="Set variable for architecture-specific image",
                         default=[])
+    optional.add_argument("--noverify", action="store_false", default=True, dest="verify",
+                        help="Do not verify the install root")
 
     # add the show version option
     parser.add_argument("-V", help="show program's version number and exit",
@@ -200,7 +202,7 @@ def main(args):
               add_template_vars=parsed_add_template_vars,
               add_arch_templates=opts.add_arch_templates,
               add_arch_template_vars=parsed_add_arch_template_vars,
-              remove_temp=True)
+              remove_temp=True, verify=opts.verify)
 
 
 def get_dnf_base_object(installroot, repositories, mirrorlists=None,


### PR DESCRIPTION
spice-vdagent, part of the thing that makes copy/paste work between a host and a virt guest, is missing libraries in rawhide. It isn't as noticeable when spice-vdagent breaks as it is, say, when dhclient breaks, so it's probably been broken for a little while. I would like changes like this to be less of a surprise.

I don't have any strong opinions about whether verify should be on or off by default as long as the jenkins job runs with it on.