### PR TITLE
Fix chronyd not working in the installation (#1085013)

### DIFF
--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -319,7 +319,7 @@ removefrom util-linux --allbut \
     /etc/mtab /etc/pam.d/login /etc/pam.d/remote \
     /usr/sbin/{agetty,blkid,blockdev,clock,fdisk,fsck,fstrim,hwclock,losetup} \
     /usr/sbin/{mkswap,nologin,sfdisk,swapoff,swapon,wipefs,partx} \
-    /usr/bin/{logger,hexdump}
+    /usr/bin/{logger,hexdump,flock}
 removefrom volume_key-libs /usr/share/locale/*
 removefrom wget /etc/* /usr/share/locale/*
 removefrom xorg-x11-drv-intel /usr/${libdir}/libI*


### PR DESCRIPTION
Service chronyd not working on rhel7 now because it's missing command flock.

**In installation:**
```
systemctl status chronyd
chrony-helper[1685]: /usr/libexec/chrony-helper: line 139: flock: command not found
chrony-helper[1685]: Failed to lock /var/run/chrony-helper
```

*Related: rhbz#1085013*