### PR TITLE
Kill fedup

### DIFF
--- a/docs/lorax.1
+++ b/docs/lorax.1
@@ -79,9 +79,6 @@ volume id
 \fB\-\-nomacboot\fR
 
 .TP
-\fB\-\-noupgrade\fR
-
-.TP
 \fB\-\-logfile=LOGFILE\fR
 Path to logfile
 
@@ -95,4 +92,3 @@ Martin Gracik
 Will Woods
 Brian C. Lane
 .fi
-

--- a/lorax.spec
+++ b/lorax.spec
@@ -47,8 +47,6 @@ Requires:       python3-dnf
 
 %if 0%{?fedora}
 # Fedora specific deps
-Requires:       fedup-dracut
-Requires:       fedup-dracut-plymouth
 %ifarch x86_64
 Requires:       hfsplus-tools
 %endif

--- a/share/aarch64.tmpl
+++ b/share/aarch64.tmpl
@@ -17,9 +17,6 @@ mkdir ${KERNELDIR}
     ## normal aarch64
     installkernel images-${basearch} ${kernel.path} ${KERNELDIR}/vmlinuz
     installinitrd images-${basearch} ${kernel.initrd.path} ${KERNELDIR}/initrd.img
-    %if doupgrade:
-        installupgradeinitrd images-${basearch} ${kernel.upgrade.path} ${KERNELDIR}/upgrade.img
-    %endif
 %endfor
 
 #FIXME: this will need adjusted when we have a real bootloader.

--- a/share/arm.tmpl
+++ b/share/arm.tmpl
@@ -36,22 +36,6 @@ mkdir ${KERNELDIR}
         platforms = platforms + delimiter + kernel.flavor
         delimiter = ','
 %>
-
-        %if doupgrade:
-            ## install upgrade image
-            installupgradeinitrd images-${kernel.flavor}-${basearch} ${kernel.upgrade.path} ${KERNELDIR}/upgrade-${kernel.flavor}.img
-
-            runcmd mkimage \
-                 -A arm -O linux -T ramdisk -C none \
-                 -a 0 -e 0 \
-                 -n "${product.name} ${product.version} ${kernel.flavor} ${kernel.arch}" \
-                 -d ${outroot}/${KERNELDIR}/upgrade-${kernel.flavor}.img \
-                    ${outroot}/${KERNELDIR}/uUpgrade-${kernel.flavor}
-
-            treeinfo images-${kernel.flavor}-${basearch} uupgrade ${KERNELDIR}/uUpgrade-${kernel.flavor}
-
-        %endif
-
         ## create U-Boot wrapped images
 
         runcmd mkimage \
@@ -74,21 +58,6 @@ mkdir ${KERNELDIR}
     %else:
         installkernel images-${basearch} ${kernel.path} ${KERNELDIR}/vmlinuz
         installinitrd images-${basearch} ${kernel.initrd.path} ${KERNELDIR}/initrd.img
-
-        %if doupgrade:
-            ## install upgrade image
-            installupgradeinitrd images-${basearch} ${kernel.upgrade.path} ${KERNELDIR}/upgrade.img
-
-	    runcmd mkimage \
-                -A arm -O linux -T ramdisk -C none \
-                -a 0 -e 0 \
-                -n "${product.name} ${product.version} ${kernel.flavor} ${kernel.arch}" \
-                -d ${outroot}/${KERNELDIR}/upgrade.img \
-                   ${outroot}/${KERNELDIR}/uUpgrade
-
-            treeinfo images-${basearch} uupgrade ${KERNELDIR}/uUpgrade
-
-        %endif
 
         ## create U-Boot wrapped images
 
@@ -131,4 +100,3 @@ treeinfo ${basearch} platforms ${platforms}
 %>
 
 ## FIXME: ARM may need some extra boot config
-

--- a/share/ppc.tmpl
+++ b/share/ppc.tmpl
@@ -68,11 +68,6 @@ install ${configdir}/mapping ${BOOTDIR}
     installkernel images-${kernel.arch} ${kernel.path} ${KERNELDIR}/vmlinuz
     installinitrd images-${kernel.arch} ${kernel.initrd.path} ${KERNELDIR}/initrd.img
 
-    %if doupgrade:
-        ## upgrade image
-        installupgradeinitrd images-${kernel.arch} ${kernel.upgrade.path} ${KERNELDIR}/upgrade.img
-    %endif
-
     ## kernel-wrapper magic that makes the netboot combined ppc{32,64}.img
     runcmd ${inroot}/${WRAPPER} -p of \
            -D ${inroot}/${WRAPPER_DATA} \

--- a/share/ppc64le.tmpl
+++ b/share/ppc64le.tmpl
@@ -54,11 +54,6 @@ install ${configdir}/mapping ${BOOTDIR}
     installkernel images-${kernel.arch} ${kernel.path} ${KERNELDIR}/vmlinuz
     installinitrd images-${kernel.arch} ${kernel.initrd.path} ${KERNELDIR}/initrd.img
 
-    %if doupgrade:
-        ## upgrade image
-        installupgradeinitrd images-${kernel.arch} ${kernel.upgrade.path} ${KERNELDIR}/upgrade.img
-    %endif
-
     treeinfo images-${kernel.arch} zimage
 %endfor
 

--- a/share/runtime-install.tmpl
+++ b/share/runtime-install.tmpl
@@ -52,12 +52,7 @@ installpkg plymouth
 ## extra dracut modules
 installpkg anaconda-dracut dracut-network dracut-config-generic
 
-## fedup-dracut handles upgrades
-installpkg fedup-dracut fedup-dracut-plymouth
-## install other fedup scripts, if there are any. It's OK if there aren't.
-log "Looking for extra fedup-dracut packages..."
--installpkg *-fedup-dracut
-## fedup and rescue need this
+## rescue needs this
 installpkg cryptsetup
 
 ## rpcbind or portmap needed by dracut nfs module

--- a/share/s390.tmpl
+++ b/share/s390.tmpl
@@ -26,11 +26,6 @@ replace @INITRD_LOAD_ADDRESS@ ${INITRD_ADDRESS} generic.ins
 installkernel images-${basearch} ${kernel.path} ${KERNELDIR}/kernel.img
 installinitrd images-${basearch} ${kernel.initrd.path} ${KERNELDIR}/initrd.img
 
-%if doupgrade:
-    ## upgrader image
-    installupgradeinitrd images-${basearch} ${kernel.upgrade.path} ${KERNELDIR}/upgrade.img
-%endif
-
 ## s390 needs some extra boot config
 createaddrsize ${INITRD_ADDRESS} ${outroot}/${BOOTDIR}/initrd.img ${outroot}/${BOOTDIR}/initrd.addrsize
 

--- a/share/x86.tmpl
+++ b/share/x86.tmpl
@@ -44,30 +44,18 @@ mkdir ${KERNELDIR}
         ## i386 PAE
         installkernel images-xen ${kernel.path} ${KERNELDIR}/vmlinuz-${kernel.flavor}
         installinitrd images-xen ${kernel.initrd.path} ${KERNELDIR}/initrd-${kernel.flavor}.img
-        %if doupgrade:
-            installupgradeinitrd images-xen ${kernel.upgrade.path} ${KERNELDIR}/upgrade-${kernel.flavor}.img
-        %endif
     %else:
         ## normal i386, x86_64
         installkernel images-${basearch} ${kernel.path} ${KERNELDIR}/vmlinuz
         installinitrd images-${basearch} ${kernel.initrd.path} ${KERNELDIR}/initrd.img
-        %if doupgrade:
-            installupgradeinitrd images-${basearch} ${kernel.upgrade.path} ${KERNELDIR}/upgrade.img
-        %endif
     %endif
 %endfor
 
 hardlink ${KERNELDIR}/vmlinuz ${BOOTDIR}
 hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
-%if doupgrade:
-    hardlink ${KERNELDIR}/upgrade.img ${BOOTDIR}
-%endif
 %if basearch == 'x86_64':
     treeinfo images-xen kernel ${KERNELDIR}/vmlinuz
     treeinfo images-xen initrd ${KERNELDIR}/initrd.img
-    %if doupgrade:
-        treeinfo images-xen upgrade ${KERNELDIR}/upgrade.img
-    %endif
 %endif
 
 ## WHeeeeeeee, EFI.

--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -338,21 +338,6 @@ class Lorax(BaseLoraxClass):
 
         treebuilder.rebuild_initrds(add_args=anaconda_args)
 
-        if doupgrade:
-            # Build upgrade.img. It'd be nice if these could coexist in the same
-            # image, but that would increase the size of the anaconda initramfs,
-            # which worries some people (esp. PPC tftpboot). So they're separate.
-            try:
-                # If possible, use the 'fedup' plymouth theme
-                themes = runcmd_output(['plymouth-set-default-theme', '--list'],
-                                       root=installroot)
-                if 'fedup' in themes.splitlines():
-                    os.environ['PLYMOUTH_THEME_NAME'] = 'fedup'
-            except RuntimeError:
-                pass
-            upgrade_args = dracut_args + ["--add", "system-upgrade"]
-            treebuilder.rebuild_initrds(add_args=upgrade_args, prefix="upgrade")
-
         logger.info("populating output tree and building boot images")
         treebuilder.build()
 


### PR DESCRIPTION
These patches make lorax stop building `upgrade.img` and stop requiring `fedup-dracut` and friends. 

For backward-compatibility, the API and CLI have been left unchanged. `--noupgrade` is still accepted and `doupgrade` still gets passed into the templates. It just doesn't do anything.

This is intended for f23-branch and master, so it might need backporting.

_NOTE_: there's one place in `pylorax/__init__.py` that might want some tweaking:
```python
        # ppc64 cannot boot an initrd > 32MiB so remove some drivers
        if self.arch.basearch in ("ppc64", "ppc64le"):
            dracut_args.extend(["--omit-drivers", REMOVE_PPC64_DRIVERS])

            # Only omit dracut modules from the initrd so that they're kept for
            # upgrade.img
            anaconda_args.extend(["--omit", REMOVE_PPC64_MODULES])
```
As far as I can tell, though, that shouldn't hurt anything