### PR TITLE
Don't include early microcode in initramfs (#1258498)

### DIFF
--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -307,7 +307,7 @@ class Lorax(BaseLoraxClass):
                                   workdir=self.workdir)
 
         logger.info("rebuilding initramfs images")
-        dracut_args = ["--xz", "--install", "/.buildstamp"]
+        dracut_args = ["--xz", "--install", "/.buildstamp", "--no-early-microcode"]
         anaconda_args = dracut_args + ["--add", "anaconda pollcdrom"]
 
         # ppc64 cannot boot an initrd > 32MiB so remove some drivers

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -66,7 +66,7 @@ except ImportError:
 
 # Default parameters for rebuilding initramfs, override with --dracut-args
 DRACUT_DEFAULT = ["--xz", "--add", "livenet dmsquash-live convertfs pollcdrom",
-                  "--omit", "plymouth", "--no-hostonly"]
+                  "--omit", "plymouth", "--no-hostonly", "--no-early-microcode"]
 
 ROOT_PATH = "/mnt/sysimage/"
 RUNTIME = "images/install.img"


### PR DESCRIPTION
The system the image boots on will likely not match the host where lorax
was run, and in some cases this can cause systems to hang.

Resolves: rhbz#1258498