### PR TITLE
livemedia-creator: Remove random-seed from images (#1258986)

### DIFF
--- a/docs/fedora-minimized.ks
+++ b/docs/fedora-minimized.ks
@@ -37,6 +37,9 @@ part swap --size=1000
 %post
 # Remove root password
 passwd -d root > /dev/null
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
 %end
 
 %packages

--- a/docs/rhel7-livemedia.ks
+++ b/docs/rhel7-livemedia.ks
@@ -308,6 +308,8 @@ rm -f /core*
 rm -f /.readahead_collect
 touch /var/lib/readahead/early.sorted
 
+# Remove random-seed
+rm /var/lib/systemd/random-seed
 %end
 
 %post --nochroot

--- a/docs/rhel7-minimal.ks
+++ b/docs/rhel7-minimal.ks
@@ -38,6 +38,9 @@ part swap --size=1000
 %post
 # Remove root password
 passwd -d root > /dev/null
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
 %end
 
 %packages


### PR DESCRIPTION
systemd uses /var/lib/systemd/random-seed to add entropy to /dev/urandom
at boot time. During image creation this file is created, and if not
removed everything using the image will be adding the same seed.

This is only additional entropy, NOT a seed in the sense of a starting
point for a PRNG, so it will be mixed with other entropy as the system
runs. It isn't a good idea to use the same value everywhere so make sure
it is removed in %post

Resolves: rhbz#1258986