### PR TITLE
Crash handling

### DIFF
--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -187,6 +187,7 @@ removefrom file-libs /usr/share/*
 removefrom findutils /usr/bin/oldfind /usr/share/*
 removefrom fontconfig /usr/bin/*
 removefrom gawk /usr/bin/{igawk,pgawk} /usr/libexec/* /usr/share/*
+removefrom gdb /usr/share/* /usr/include/* /etc/gdbinit*
 removefrom gdisk /usr/share/*
 removefrom gdk-pixbuf2 /usr/share/locale*
 removefrom gfs2-utils /usr/sbin/*

--- a/share/runtime-install.tmpl
+++ b/share/runtime-install.tmpl
@@ -6,6 +6,8 @@ installpkg anaconda anaconda-widgets
 installpkg kexec-tools-anaconda-addon
 ## anaconda deps that aren't in the RPM
 installpkg tmux
+## for anaconda crash handling
+installpkg gdb
 ## Other available payloads
 installpkg dnf
 installpkg rpm-ostree

--- a/src/pylorax/monitor.py
+++ b/src/pylorax/monitor.py
@@ -105,6 +105,7 @@ class LogRequestHandler(socketserver.BaseRequestHandler):
                         "insufficient disk space:",
                         "error populating transaction after",
                         "traceback script(s) have been run",
+                        "crashed on signal",
                         "packaging: Missed: NoSuchPackage"]
         re_tests =     [r"packaging: base repo .* not valid",
                         r"packaging: .* requires .*"]


### PR DESCRIPTION
The first commit adds gdb to the boot.iso. This is the easiest way I've found to generate a core file in a predictable manner. Altogether adds about 6MB to boot.iso on x86_64.

The second commit is to get livemedia-creator to look for an error message that I'm about to add to anaconda.