### PR TITLE
livemedia-creator: Also generate an iPXE config

### DIFF
--- a/share/pxe-live/ipxe-config.tmpl
+++ b/share/pxe-live/ipxe-config.tmpl
@@ -1,0 +1,5 @@
+#!ipxe
+set base-url http://example.com/  # You must download the files referenced here and change this URL
+kernel <%text>${base-url}</%text>${kernel} root=live:<%text>${base-url}/</%text>${liveimg} ${addargs}
+initrd <%text>${base-url}</%text>${initrd}
+boot

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -567,11 +567,12 @@ def rebuild_initrds_for_live(opts, sys_root_dir, results_dir):
 
     os.unlink(joinpaths(sys_root_dir,"/proc/modules"))
 
-def create_pxe_config(template, images_dir, live_image_name, add_args = None):
+def create_pxe_config(template, images_dir, destname, live_image_name, add_args = None):
     """
     Create template for pxe to live configuration
 
     :param str images_dir: Path of directory with images to be used
+    :param str destname: Basename of target file to generate
     :param str live_image_name: Name of live rootfs image file
     :param list add_args: Arguments to be added to initrd= pxe config
     """
@@ -596,7 +597,7 @@ def create_pxe_config(template, images_dir, live_image_name, add_args = None):
         log.error(text_error_template().render())
         raise
 
-    with open (joinpaths(images_dir, "PXE_CONFIG"), "w") as f:
+    with open (joinpaths(images_dir, destname), "w") as f:
         f.write(result)
 
 def make_livecd(opts, mount_dir, work_dir):
@@ -953,8 +954,9 @@ def make_live_images(opts, work_dir, root_dir, rootfs_image=None, size=None):
 
     if opts.ostree:
         add_pxe_args.append("ostree=/%s" % sys_root)
-    template = joinpaths(opts.lorax_templates, "pxe-live/pxe-config.tmpl")
-    create_pxe_config(template, work_dir, live_image_name, add_pxe_args)
+    for template,dest in [("pxe-config.tmpl", "PXE_CONFIG"),
+                          ("ipxe-config.tmpl", "ipxe-config.txt")]:
+        create_pxe_config(joinpaths(opts.lorax_templates, "pxe-live/" + template), work_dir, dest, live_image_name, add_pxe_args)
 
     return work_dir
 


### PR DESCRIPTION
Currently lmc has some ad-hoc code to generate a `PXE_CONFIG`.
In practice we should probably split this out somehow, as in reality
downstream users need to edit it.  So it should be more explicitly
a template.

That aside, it turns out there's also iPXE which in addition to having
the critical `i` prefix, supports http and variable substitution in
the config file itself.

This makes it a lot more convenient to use - downstream users can more
easily edit the `set base-url` and have things work, it's easy to put
an iPXE config into a pastebin etc.
