### PR TITLE
Disable systemd-tmpfiles-setup.

### DIFF
--- a/share/runtime-postinstall.tmpl
+++ b/share/runtime-postinstall.tmpl
@@ -42,7 +42,7 @@ systemctl mask fedora-configure.service fedora-loadmodules.service \
                fedora-autorelabel.service fedora-autorelabel-mark.service \
                fedora-wait-storage.service media.mount \
                systemd-tmpfiles-clean.service systemd-tmpfiles-clean.timer \
-               ldconfig.service
+               ldconfig.service systemd-tmpfiles-setup.service
 
 ## Make logind activate anaconda-shell@.service on switch to empty VT
 symlink anaconda-shell@.service lib/systemd/system/autovt@.service


### PR DESCRIPTION
Most of the files configured by tempfiles are not relevant when an
actual factual /etc is present. Some of the files configured by
tempfiles are actively hostile. Quit letting systemd crud up the
filesystem and let the packages take care of the files that really
matter.