### PR TITLE
Fix the concatenation of error output.

### DIFF
--- a/src/pylorax/executils.py
+++ b/src/pylorax/executils.py
@@ -195,7 +195,7 @@ def _run_program(argv, root='/', stdin=None, stdout=None, env_prune=None, log_ou
         program_log.debug("Return code: %d", proc.returncode)
 
     if proc.returncode and raise_err:
-        output = output_string or "" + err_string or ""
+        output = (output_string or "") + (err_string or "")
         raise subprocess.CalledProcessError(proc.returncode, argv, output)
 
     return (proc.returncode, output_string)


### PR DESCRIPTION
The "x or y" construct does not have the precedence it looks like it
has.