### PR TITLE
Enable gtk inspector.

### DIFF
--- a/share/config_files/common/org.gtk.Settings.Debug.gschema.override
+++ b/share/config_files/common/org.gtk.Settings.Debug.gschema.override
@@ -1,0 +1,2 @@
+[org.gtk.Settings.Debug]
+	enable-inspector-keybinding=true

--- a/share/runtime-postinstall.tmpl
+++ b/share/runtime-postinstall.tmpl
@@ -94,6 +94,10 @@ replace "root:\*:" "root::" etc/shadow
 ## gconf settings
 gconfset /desktop/gnome/interface/accessibility bool true
 
+## gsettings settings
+install ${configdir}/org.gtk.Settings.Debug.gschema.override usr/share/glib-2.0/schemas
+runcmd chroot ${root} glib-compile-schemas /usr/share/glib-2.0/schemas
+
 move usr/libexec/anaconda/auditd sbin
 
 ## for compatibility with Ancient Anaconda Traditions


### PR DESCRIPTION
Gtk turned off the inspector keybindings by default, because they were
interfering with applications that use a lot of complicated keyboard
shortcuts. This is not a concern for anaconda, and the inspector is
pretty handy, so turn it back on.