### PR TITLE
Make OCI and Vagrant images

### DIFF
--- a/docs/fedora-vagrant.ks
+++ b/docs/fedora-vagrant.ks
@@ -1,0 +1,69 @@
+# Minimal Vagrant Disk Image
+#
+
+# Firewall configuration
+firewall --enabled
+# Use network installation
+url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/x86_64/os/"
+
+# Root account is locked, access via sudo from vagrant user
+rootpw --lock
+
+# Vagrant user with the INSECURE default public key
+user --name=vagrant
+sshkey --username=vagrant "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
+
+# System authorization information
+auth --useshadow --enablemd5
+# System keyboard
+keyboard --xlayouts=us --vckeymap=us
+# System language
+lang en_US.UTF-8
+# SELinux configuration
+selinux --enforcing
+# Installation logging level
+logging --level=info
+# Shutdown after installation
+shutdown
+# System timezone
+timezone  US/Eastern
+# System bootloader configuration
+bootloader --location=mbr
+# Partition clearing information
+clearpart --all --initlabel
+# Disk partitioning information
+part / --fstype="ext4" --size=4000
+part swap --size=1000
+
+%post
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+
+# Setup sudoers for Vagrant
+echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+sed -i 's/Defaults\s*requiretty/Defaults !requiretty/' /etc/sudoers
+
+# SSH setup
+sed -i 's/.*UseDNS.*/UseDNS no/' /etc/ssh/sshd_config
+%end
+
+%packages --excludedocs
+@core
+kernel
+memtest86+
+grub2-efi
+grub2
+shim
+syslinux
+-dracut-config-rescue
+
+# dracut needs these included
+dracut-network
+tar
+
+# Useful tools for Vagrant
+openssh-server
+openssh-clients
+sudo
+rsync
+%end

--- a/docs/livemedia-creator.rst
+++ b/docs/livemedia-creator.rst
@@ -436,6 +436,24 @@ And then run bash inside of it:
     ``sudo docker run -i -t fedora-root /bin/bash``
 
 
+Open Container Initiative Image Creation
+----------------------------------------
+
+The OCI is a new specification that is still being worked on. You can read more about it at
+`the Open Container Initiative website <https://www.opencontainers.org/>`. You can create
+OCI images using the following command::
+
+    sudo livemedia-creator --make-oci --oci-config /path/to/config.json --oci-runtime /path/to/runtime.json \
+    --iso=/path/to/boot.iso --ks=/path/to/fedora-minimal.ks
+
+You must provide the config.json and runtime.json files to be included in the bundle,
+their specifications can be found `on the OCI github project <https://github.com/opencontainers/specs>`
+output will be in the results directory with a default name of bundle.tar.xz
+
+This will work with ``--no-virt`` and inside a mock since it doesn't use any
+partitioned disk images.
+
+
 Debugging problems
 ------------------
 

--- a/docs/livemedia-creator.rst
+++ b/docs/livemedia-creator.rst
@@ -454,6 +454,31 @@ This will work with ``--no-virt`` and inside a mock since it doesn't use any
 partitioned disk images.
 
 
+Vagrant Image Creation
+----------------------
+
+`Vagrant <https://www.vagrantup.com/>` images can be created using the following command::
+
+    sudo livemedia-creator --make-vagrant --vagrant-metadata /path/to/metadata.json \
+    --iso=/path/to/boot.iso --ks=/path/to/fedora-vagrant.ks
+
+The image created is a `vagrant-libvirt
+<https://github.com/pradels/vagrant-libvirt>` provider image and needs to have
+vagrant setup with libvirt before you can use it.
+
+The ``--vagrant-metadata`` file is optional, it will create a minimal one by
+default, and if one is passed it will make sure the disk size  is setup
+correctly. If you pass a ``--vagrant-vagrantfile`` it will be included in the
+image verbatim. By default no vagrantfile is created.
+
+There is an example Vagrant kickstart file in the docs directory that sets up
+the vagrant user with the default insecure SSH pubkey and a few useful
+utilities.
+
+This also works with ``--no-virt``, but will not work inside a mock due to its
+use of partitioned disk images and qcow2.
+
+
 Debugging problems
 ------------------
 

--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -80,10 +80,13 @@ def mkcpio(rootdir, outfile, compression="xz", compressargs=None):
     return compress(["cpio", "--null", "--quiet", "-H", "newc", "-o"],
                     rootdir, outfile, compression, compressargs)
 
-def mktar(rootdir, outfile, compression="xz", compressargs=None):
+def mktar(rootdir, outfile, compression="xz", compressargs=None, selinux=True):
     compressargs = compressargs or ["-9"]
-    return compress(["tar", "--no-recursion", "--selinux", "--acls", "--xattrs", "-cf-", "--null", "-T-"],
-                    rootdir, outfile, compression, compressargs)
+    tar_cmd = ["tar", "--no-recursion"]
+    if selinux:
+        tar_cmd += ["--selinux", "--acls", "--xattrs"]
+    tar_cmd += ["-cf-", "--null", "-T-"]
+    return compress(tar_cmd, rootdir, outfile, compression, compressargs)
 
 def mksquashfs(rootdir, outfile, compression="default", compressargs=None):
     '''Make a squashfs image containing the given rootdir.'''

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -32,6 +32,8 @@ import shutil
 import argparse
 import hashlib
 import glob
+import json
+from math import ceil
 
 # Use pykickstart to calculate disk image size
 from pykickstart.parser import KickstartParser
@@ -440,6 +442,41 @@ def create_pxe_config(template, images_dir, live_image_name, add_args = None):
     with open (joinpaths(images_dir, "PXE_CONFIG"), "w") as f:
         f.write(result)
 
+
+def create_vagrant_metadata(path, size=0):
+    """ Create a default Vagrant metadata.json file
+
+    :param str path: Path to metadata.json file
+    :param int size: Disk size in MiB
+    """
+    metadata = { "provider":"libvirt", "format":"qcow2", "virtual_size": ceil(size / 1024) }
+    with open(path, "wt") as f:
+        json.dump(metadata, f, indent=4)
+
+
+def update_vagrant_metadata(path, size):
+    """ Update the Vagrant metadata.json file
+
+    :param str path: Path to metadata.json file
+    :param int size: Disk size in MiB
+
+    This function makes sure that the provider, format and virtual size of the
+    metadata file are set correctly. All other values are left untouched.
+    """
+    with open(path, "rt") as f:
+        try:
+            metadata = json.load(f)
+        except ValueError as e:
+            log.error("Problem reading metadata file %s: %s", path, e)
+            return
+
+    metadata["provider"] = "libvirt"
+    metadata["format"] = "qcow2"
+    metadata["virtual_size"] = ceil(size / 1024)
+    with open(path, "wt") as f:
+        json.dump(metadata, f, indent=4)
+
+
 def make_livecd(opts, mount_dir, work_dir):
     """
     Take the content from the disk image and make a livecd out of it
@@ -673,6 +710,12 @@ def novirt_install(opts, disk_img, disk_size, repo_url):
         qcow2_img = tempfile.mktemp(prefix="disk", suffix=".img")
         execWithRedirect("qemu-img", ["convert"] + qcow2_args + [disk_img, qcow2_img], raise_err=True)
         execWithRedirect("mv", ["-f", qcow2_img, disk_img], raise_err=True)
+
+        if opts.make_vagrant:
+            pass
+
+            # tar the qcow2 file and optional json files
+
     elif opts.make_tar:
         compress_args = []
         for arg in opts.compress_args:
@@ -786,6 +829,25 @@ def virt_install(opts, install_log, disk_img, disk_size):
                 rc = mktar(img_mount.temp_dir, disk_img, opts.compression, compress_args)
         os.unlink(diskimg_path)
 
+        if rc:
+            raise InstallError("virt_install failed")
+    elif opts.make_vagrant:
+        compress_args = []
+        for arg in opts.compress_args:
+            compress_args += arg.split(" ", 1)
+
+        vagrant_dir = tempfile.mkdtemp()
+        metadata_path = joinpaths(vagrant_dir, "metadata.json")
+        execWithRedirect("mv", ["-f", disk_img, joinpaths(vagrant_dir, "box.img")], raise_err=True)
+        if opts.vagrant_metadata:
+            shutil.copy2(opts.vagrant_metadata, metadata_path)
+        else:
+            create_vagrant_metadata(metadata_path)
+        update_vagrant_metadata(metadata_path, disk_size)
+        if opts.vagrantfile:
+            shutil.copy2(opts.vagrantfile, joinpaths(vagrant_dir, "vagrantfile"))
+
+        rc = mktar(vagrant_dir, disk_img, opts.compression, compress_args, selinux=False)
         if rc:
             raise InstallError("virt_install failed")
 
@@ -943,6 +1005,8 @@ def main():
                         help="Build a live pxe boot squashfs image of Atomic Host")
     action.add_argument("--make-oci", action="store_true",
                         help="Build an Open Container Initiative image")
+    action.add_argument("--make-vagrant", action="store_true",
+                        help="Build a Vagrant Box image")
 
     parser.add_argument("--iso", type=os.path.abspath,
                         help="Anaconda installation .iso path to use for virt-install")
@@ -1050,6 +1114,13 @@ def main():
     oci_group.add_argument("--oci-runtime",
                               help="runtime.json OCI configuration file")
 
+    # Vagrant specific commands
+    vagrant_group = parser.add_argument_group("Vagrant arguments")
+    vagrant_group.add_argument("--vagrant-metadata",
+                               help="optional metadata.json file")
+    vagrant_group.add_argument("--vagrantfile",
+                               help="optional vagrantfile")
+
     parser.add_argument("--title", default="Linux Live Media",
                         help="Substituted for @TITLE@ in bootloader config files")
     parser.add_argument("--project", default="Linux",
@@ -1122,6 +1193,10 @@ def main():
     if opts.image_name and os.path.exists(joinpaths(opts.result_dir, opts.image_name)):
         errors.append("The disk image to be created should not exist.")
 
+    # Vagrant creates a qcow2 inside a tar, turn on qcow2
+    if opts.make_vagrant:
+        opts.qcow2 = True
+
     if opts.qcow2 and not os.path.exists("/usr/bin/qemu-img"):
         errors.append("qcow2 requires the qemu-img utility to be installed.")
 
@@ -1150,7 +1225,7 @@ def main():
         list(log.error(e) for e in errors)
         sys.exit(1)
 
-    # Default to putting results into tmp
+    # Default to putting results under tmp
     if not opts.result_dir:
         opts.result_dir = opts.tmp
     else:
@@ -1173,7 +1248,11 @@ def main():
             opts.image_name = "bundle.tar.xz"
         if opts.compression == "xz" and not opts.compress_args:
             opts.compress_args = ["-9"]
-
+    elif opts.make_vagrant:
+        if not opts.image_name:
+            opts.image_name = "vagrant.tar.xz"
+        if opts.compression == "xz" and not opts.compress_args:
+            opts.compress_args = ["-9"]
 
     if opts.app_file:
         opts.app_file = joinpaths(opts.result_dir, opts.app_file)

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -563,6 +563,7 @@ def novirt_install(opts, disk_img, disk_size, repo_url):
     or tarfile.
     """
     import selinux
+    dirinstall_path = ROOT_PATH
 
     # Set selinux to Permissive if it is Enforcing
     selinux_enforcing = False
@@ -589,17 +590,22 @@ def novirt_install(opts, disk_img, disk_size, repo_url):
         args += ["--dirinstall"]
 
         mkext4img(None, disk_img, label=opts.fs_label, size=disk_size * 1024**2)
-        if not os.path.isdir(ROOT_PATH):
-            os.mkdir(ROOT_PATH)
-        mount(disk_img, opts="loop", mnt=ROOT_PATH)
-    elif opts.make_tar:
-        args += ["--dirinstall"]
+        if not os.path.isdir(dirinstall_path):
+            os.mkdir(dirinstall_path)
+        mount(disk_img, opts="loop", mnt=dirinstall_path)
+    elif opts.make_tar or opts.make_oci:
+        # Install under dirinstall_path, make sure it starts clean
+        if os.path.exists(dirinstall_path):
+            shutil.rmtree(dirinstall_path)
 
-        # Install directly into ROOT_PATH, make sure it starts clean
-        if os.path.exists(ROOT_PATH):
-            shutil.rmtree(ROOT_PATH)
-        if not os.path.isdir(ROOT_PATH):
-            os.mkdir(ROOT_PATH)
+        if opts.make_oci:
+            # OCI installs under /rootfs/
+            dirinstall_path = joinpaths(dirinstall_path, "rootfs")
+            args += ["--dirinstall", dirinstall_path]
+        else:
+            args += ["--dirinstall"]
+
+        os.makedirs(dirinstall_path)
     else:
         args += ["--image", disk_img]
 
@@ -619,14 +625,14 @@ def novirt_install(opts, disk_img, disk_size, repo_url):
             log.info(line)
 
         # Make sure the new filesystem is correctly labeled
-        args = ["-e", "/proc", "-e", "/sys", "-e", "/dev",
-                "/etc/selinux/targeted/contexts/files/file_contexts", "/"]
-        if opts.make_iso or opts.make_fsimage or opts.make_tar:
-            execWithRedirect("setfiles", args, root=ROOT_PATH)
+        setfiles_args = ["-e", "/proc", "-e", "/sys", "-e", "/dev",
+                         "/etc/selinux/targeted/contexts/files/file_contexts", "/"]
+        if "--dirinstall" in args:
+            execWithRedirect("setfiles", setfiles_args, root=dirinstall_path)
         else:
             with PartitionMount(disk_img) as img_mount:
                 if img_mount and img_mount.mount_dir:
-                    execWithRedirect("setfiles", args, root=img_mount.mount_dir)
+                    execWithRedirect("setfiles", setfiles_args, root=img_mount.mount_dir)
     except (subprocess.CalledProcessError, OSError) as e:
         log.error("Running anaconda failed: %s", e)
         raise InstallError("novirt_install failed")
@@ -672,8 +678,21 @@ def novirt_install(opts, disk_img, disk_size, repo_url):
         for arg in opts.compress_args:
             compress_args += arg.split(" ", 1)
 
+        rc = mktar(dirinstall_path, disk_img, opts.compression, compress_args)
+        shutil.rmtree(dirinstall_path)
+
+        if rc:
+            raise InstallError("novirt_install mktar failed: rc=%s" % rc)
+    elif opts.make_oci:
+        # An OCI image places the filesystem under /rootfs/ and adds the json files at the top
+        # And then creates a tar of the whole thing.
+        compress_args = []
+        for arg in opts.compress_args:
+            compress_args += arg.split(" ", 1)
+
+        shutil.copy2(opts.oci_config, ROOT_PATH)
+        shutil.copy2(opts.oci_runtime, ROOT_PATH)
         rc = mktar(ROOT_PATH, disk_img, opts.compression, compress_args)
-        shutil.rmtree(ROOT_PATH)
 
         if rc:
             raise InstallError("novirt_install mktar failed: rc=%s" % rc)
@@ -1117,6 +1136,12 @@ def main():
 
     if opts.make_oci and not (opts.oci_config and opts.oci_runtime):
         errors.append("--make-oci requires --oci-config and --oci-runtime")
+
+    if opts.make_oci and not os.path.exists(opts.oci_config):
+        errors.append("oci % file is missing" % opts.oci_config)
+
+    if opts.make_oci and not os.path.exists(opts.oci_runtime):
+        errors.append("oci % file is missing" % opts.oci_runtime)
 
     if os.getuid() != 0:
         errors.append("You need to run this as root")

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -698,6 +698,7 @@ def novirt_install(opts, disk_img, disk_size, repo_url):
         if selinux_enforcing:
             selinux.security_setenforce(1)
 
+    # qcow2 is used by bare qcow2 images and by Vagrant
     if opts.qcow2:
         log.info("Converting %s to qcow2", disk_img)
         qcow2_args = []
@@ -709,13 +710,30 @@ def novirt_install(opts, disk_img, disk_size, repo_url):
             qcow2_args.extend(["-O", "qcow2"])
         qcow2_img = tempfile.mktemp(prefix="disk", suffix=".img")
         execWithRedirect("qemu-img", ["convert"] + qcow2_args + [disk_img, qcow2_img], raise_err=True)
-        execWithRedirect("mv", ["-f", qcow2_img, disk_img], raise_err=True)
+        if not opts.make_vagrant:
+            execWithRedirect("mv", ["-f", qcow2_img, disk_img], raise_err=True)
+        else:
+            # Take the new qcow2 image and package it up for Vagrant
+            compress_args = []
+            for arg in opts.compress_args:
+                compress_args += arg.split(" ", 1)
 
-        if opts.make_vagrant:
-            pass
+            vagrant_dir = tempfile.mkdtemp()
+            metadata_path = joinpaths(vagrant_dir, "metadata.json")
+            execWithRedirect("mv", ["-f", qcow2_img, joinpaths(vagrant_dir, "box.img")], raise_err=True)
+            if opts.vagrant_metadata:
+                shutil.copy2(opts.vagrant_metadata, metadata_path)
+            else:
+                create_vagrant_metadata(metadata_path)
+            update_vagrant_metadata(metadata_path, disk_size)
+            if opts.vagrantfile:
+                shutil.copy2(opts.vagrantfile, joinpaths(vagrant_dir, "vagrantfile"))
 
-            # tar the qcow2 file and optional json files
-
+            log.info("Creating Vagrant image")
+            rc = mktar(vagrant_dir, disk_img, opts.compression, compress_args, selinux=False)
+            if rc:
+                raise InstallError("novirt_install mktar failed: rc=%s" % rc)
+            shutil.rmtree(vagrant_dir)
     elif opts.make_tar:
         compress_args = []
         for arg in opts.compress_args:
@@ -850,6 +868,7 @@ def virt_install(opts, install_log, disk_img, disk_size):
         rc = mktar(vagrant_dir, disk_img, opts.compression, compress_args, selinux=False)
         if rc:
             raise InstallError("virt_install failed")
+        shutil.rmtree(vagrant_dir)
 
 
 def make_squashfs(disk_img, work_dir, compression="xz"):
@@ -1217,6 +1236,9 @@ def main():
 
     if opts.make_oci and not os.path.exists(opts.oci_runtime):
         errors.append("oci % file is missing" % opts.oci_runtime)
+
+    if opts.make_vagrant and opts.vagrant_metadata and not os.path.exists(opts.vagrant_metadata):
+        errors.append("Vagrant metadata file %s is missing" % opts.vagrant_metadata)
 
     if os.getuid() != 0:
         errors.append("You need to run this as root")

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -709,7 +709,7 @@ def virt_install(opts, install_log, disk_img, disk_size):
 
         mkqcow2(disk_img, disk_size*1024**2, qcow2_args)
 
-    if opts.make_fsimage or opts.make_tar:
+    if opts.make_fsimage or opts.make_tar or opts.make_oci:
         diskimg_path = tempfile.mktemp(prefix="disk", suffix=".img")
     else:
         diskimg_path = disk_img
@@ -749,6 +749,22 @@ def virt_install(opts, install_log, disk_img, disk_size):
         with PartitionMount(diskimg_path) as img_mount:
             if img_mount and img_mount.mount_dir:
                 rc = mktar(img_mount.mount_dir, disk_img, opts.compression, compress_args)
+        os.unlink(diskimg_path)
+
+        if rc:
+            raise InstallError("virt_install failed")
+    elif opts.make_oci:
+        # An OCI image places the filesystem under /rootfs/ and adds the json files at the top
+        # And then creates a tar of the whole thing.
+        compress_args = []
+        for arg in opts.compress_args:
+            compress_args += arg.split(" ", 1)
+
+        with PartitionMount(diskimg_path, submount="rootfs") as img_mount:
+            if img_mount and img_mount.temp_dir:
+                shutil.copy2(opts.oci_config, img_mount.temp_dir)
+                shutil.copy2(opts.oci_runtime, img_mount.temp_dir)
+                rc = mktar(img_mount.temp_dir, disk_img, opts.compression, compress_args)
         os.unlink(diskimg_path)
 
         if rc:
@@ -906,6 +922,8 @@ def main():
                         help="Build a live pxe boot squashfs image")
     action.add_argument("--make-ostree-live", action="store_true",
                         help="Build a live pxe boot squashfs image of Atomic Host")
+    action.add_argument("--make-oci", action="store_true",
+                        help="Build an Open Container Initiative image")
 
     parser.add_argument("--iso", type=os.path.abspath,
                         help="Anaconda installation .iso path to use for virt-install")
@@ -1006,6 +1024,12 @@ def main():
     pxelive_group.add_argument("--live-rootfs-keep-size", action="store_true",
                                 help="Keep the original size of root filesystem in live image")
 
+    # OCI specific commands
+    oci_group = parser.add_argument_group("OCI arguments")
+    oci_group.add_argument("--oci-config",
+                              help="config.json OCI configuration file")
+    oci_group.add_argument("--oci-runtime",
+                              help="runtime.json OCI configuration file")
 
     parser.add_argument("--title", default="Linux Live Media",
                         help="Substituted for @TITLE@ in bootloader config files")
@@ -1091,6 +1115,9 @@ def main():
     if opts.make_tar and opts.qcow2:
         errors.append("qcow2 cannot be used to make a tar.")
 
+    if opts.make_oci and not (opts.oci_config and opts.oci_runtime):
+        errors.append("--make-oci requires --oci-config and --oci-runtime")
+
     if os.getuid() != 0:
         errors.append("You need to run this as root")
 
@@ -1116,6 +1143,12 @@ def main():
             opts.image_name = "root.tar.xz"
         if opts.compression == "xz" and not opts.compress_args:
             opts.compress_args = ["-9"]
+    elif opts.make_oci:
+        if not opts.image_name:
+            opts.image_name = "bundle.tar.xz"
+        if opts.compression == "xz" and not opts.compress_args:
+            opts.compress_args = ["-9"]
+
 
     if opts.app_file:
         opts.app_file = joinpaths(opts.result_dir, opts.app_file)


### PR DESCRIPTION
These commits implement --make-oci and --make-vagrant

OCI is the Open Container Initiative container format (a tar with / at /rootfs/ and a couple json files). Vagrant is a tar of a qcow2 image with a metadata.json file and optional vagrantfile.
