### PR TITLE
Include qemu modules in the initrd

### DIFF
--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -326,7 +326,7 @@ class Lorax(BaseLoraxClass):
 
         logger.info("rebuilding initramfs images")
         dracut_args = ["--xz", "--install", "/.buildstamp", "--no-early-microcode"]
-        anaconda_args = dracut_args + ["--add", "anaconda pollcdrom"]
+        anaconda_args = dracut_args + ["--add", "anaconda pollcdrom qemu qemu-net"]
 
         # ppc64 cannot boot an initrd > 32MiB so remove some drivers
         if self.arch.basearch in ("ppc64", "ppc64le"):

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -65,7 +65,7 @@ except ImportError:
     libvirt = None
 
 # Default parameters for rebuilding initramfs, override with --dracut-args
-DRACUT_DEFAULT = ["--xz", "--add", "livenet dmsquash-live convertfs pollcdrom",
+DRACUT_DEFAULT = ["--xz", "--add", "livenet dmsquash-live convertfs pollcdrom qemu qemu-net",
                   "--omit", "plymouth", "--no-hostonly", "--debug", "--no-early-microcode"]
 
 ROOT_PATH = "/mnt/sysimage/"


### PR DESCRIPTION
This includes, among other things, virtio-rng. Without it the initrd may
take longer to initialize the random non-blocking pool on KVM
installations.