### PR TITLE
Update docs for product.img

### DIFF
--- a/docs/product-images.rst
+++ b/docs/product-images.rst
@@ -2,12 +2,15 @@ Product and Updates Images
 ==========================
 
 Lorax now supports creation of product.img and updates.img as part of the build
-process. This is implemented using the installimg command which will take the
-contents of a directory and create a compressed archive from it. The x86, ppc,
-ppc64le and aarch64 templates all look for /usr/share/lorax/product/ and
-/usr/share/lorax/updates/ directories while creating the final install tree. If
-there are files in those directories lorax will create images/product.img
-and/or images/updates.img
+process. This is implemented using the installimg template command which will
+take the contents of a directory and create a compressed archive from it. The
+directory must be created by one of the packages installed by
+runtime-install.tmpl or by passing ``--installpkgs <pkgname>`` to lorax at
+runtime.  The x86, ppc, ppc64le and aarch64 templates all look for
+/usr/share/lorax/product/ and /usr/share/lorax/updates/ directories in the
+install chroot while creating the final install tree. If there are files in
+those directories lorax will create images/product.img and/or
+images/updates.img
 
 These archives are just like an anaconda updates image -- their contents are
 copied over the top of the filesystem at boot time so that you can drop in


### PR DESCRIPTION
Make it clear that the contents of product.img and updates.img comes
from the install root, not from the build host's filesystem.