### PR TITLE
Add an option for disk_size in case kickstart parsing fails

### DIFF
--- a/docs/livemedia-creator.1
+++ b/docs/livemedia-creator.1
@@ -6,6 +6,7 @@ livemedia-creator \- Create live install media
 livemedia-creator [-h]
     (--make-iso | --make-disk | --make-fsimage | --make-appliance | --make-ami | --make-tar | --make-pxe-live | --make-ostree-live)
     [--iso ISO] [--disk-image DISK_IMAGE]
+    [--disk-size DISK_SIZE]
     [--fs-image FS_IMAGE] [--ks KS]
     [--image-name IMAGE_NAME] [--image-only]
     [--fs-label FS_LABEL]
@@ -88,6 +89,10 @@ Anaconda installation .iso path to use for virt-install
 .TP
 \fB\-\-disk\-image DISK_IMAGE\fR
 Path to disk image to use for creating final image
+
+.TP
+\fB\-\-disk\-size DISK_SIZE\fR
+Size of final disk image in GiB.
 
 .TP
 \fB\-\-fs\-image FS_IMAGE\fR

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -929,7 +929,9 @@ def make_image(opts, ks):
     """
     # Disk size for a filesystem image should only be the size of /
     # to prevent surprises when using the same kickstart for different installations.
-    if opts.no_virt and (opts.make_iso or opts.make_fsimage):
+    if opts.disk_size:
+        disk_size = 1024 * opts.disk_size
+    elif opts.no_virt and (opts.make_iso or opts.make_fsimage):
         disk_size = 2 + sum(p.size for p in ks.handler.partition.partitions if p.mountpoint == "/")
     else:
         disk_size = 2 + sum(p.size for p in ks.handler.partition.partitions)
@@ -1090,6 +1092,8 @@ def main():
     image_group = parser.add_argument_group("disk/fs image arguments")
     image_group.add_argument("--disk-image", type=os.path.abspath,
                              help="Path to existing disk image to use for creating final image.")
+    image_group.add_argument("--disk-size",
+                             help="Size of the disk image to use, in GiB.")
     image_group.add_argument("--keep-image", action="store_true",
                              help="Keep raw disk image after .iso creation")
     image_group.add_argument("--fs-image", type=os.path.abspath,


### PR DESCRIPTION
In cases where the passed kickstart does not have any partition sizes specified (autopart or similar), livemedia-creator defaults to a 2MiB disk, which is too small for many use cases.

Add an option to specify the disk size in GiB in case users want to override the default logic.