### PR TITLE
livemedia-creator: Fix calculation of disk_size in some cases

### DIFF
--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -929,10 +929,11 @@ def make_image(opts, ks):
     """
     # Disk size for a filesystem image should only be the size of /
     # to prevent surprises when using the same kickstart for different installations.
+    unique_partitions = dict((p.mountpoint, p) for p in ks.handler.partition.partitions)
     if opts.no_virt and (opts.make_iso or opts.make_fsimage):
-        disk_size = 2 + sum(p.size for p in ks.handler.partition.partitions if p.mountpoint == "/")
+        disk_size = 2 + sum(p.size for p in unique_partitions.values() if p.mountpoint == "/")
     else:
-        disk_size = 2 + sum(p.size for p in ks.handler.partition.partitions)
+        disk_size = 2 + sum(p.size for p in unique_partitions.values())
     log.info("disk_size = %sMiB", disk_size)
 
     if opts.image_name:


### PR DESCRIPTION
If the kickstart includes multiple definitions for the same mount point, the last one defined is used. The current code includes all of them in size calculation, and the image file that `livemedia-creator` makes is big enough to hold all of the partitions, even though the duplicates are ignored by Anaconda.

I tested this on the f21 version of `livemedia-creator`, which is a little behind. The code at this point is slightly different. Please let me know if this is no longer a problem in bleeding-edge `livemedia-creator`, or if this fix is no longer a valid approach.

Thanks,

--scott