### PR TITLE
Write a list of debuginfo packages to /root/debug-pkgs.log (#1068675)

### DIFF
--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -204,8 +204,8 @@ def umount(mnt,  lazy=False, maxretry=3, retrysleep=1.0):
             count += 1
             if count == maxretry:
                 raise
-            logger.warn("failed to unmount %s. retrying (%d/%d)...",
-                         mnt, count, maxretry)
+            logger.warning("failed to unmount %s. retrying (%d/%d)...",
+                           mnt, count, maxretry)
             if logger.getEffectiveLevel() <= logging.DEBUG:
                 fuser = execWithCapture("fuser", ["-vm", mnt])
                 logger.debug("fuser -vm:\n%s\n", fuser)

--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -185,8 +185,6 @@ class LoraxTemplateRunner(object):
         If lorax is called with a debug repo find the corresponding debuginfo package
         names and write them to /root/debubg-pkgs.log on the boot.iso
         """
-        # If any of the repos are debug repos then find the debuginfo packages
-        # and write their NVR's to a logfile for later use.
         for repo in self.dbo.repos:
             repo = self.dbo.repos[repo]
             if any(True for url in repo.baseurl if "debug" in url):
@@ -196,6 +194,7 @@ class LoraxTemplateRunner(object):
             if repo.mirrorlist and "debug" in repo.mirrorlist:
                 break
         else:
+            # No debug repos
             return
 
         available = self.dbo.sack.query().available()

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -532,7 +532,7 @@ def make_livecd(opts, mount_dir, work_dir):
     isolabel = opts.volid or "{0.name}-{0.version}-{1.basearch}".format(product, arch)
     if len(isolabel) > 32:
         isolabel = isolabel[:32]
-        log.warn("Truncating isolabel to 32 chars: %s", isolabel)
+        log.warning("Truncating isolabel to 32 chars: %s", isolabel)
 
     tb = TreeBuilder(product=product, arch=arch, domacboot=opts.domacboot,
                      inroot=mount_dir, outroot=work_dir,

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -15,13 +15,6 @@ class LoraxLintConfig(PocketLintConfig):
                               ]
 
     @property
-    def disabledOptions(self):
-        return [ "I0011",           # Locally disabling %s
-                 "W0511",           # FIXME/TODO/XXX
-                 "W0141",           # Used builtin function %s
-               ]
-
-    @property
     def pylintPlugins(self):
         retval = super(LoraxLintConfig, self).pylintPlugins
         # Not using threads so we can skip these

--- a/utils/test-parse-template
+++ b/utils/test-parse-template
@@ -34,8 +34,8 @@ data.basearch = data.arch.basearch
 data.libdir = data.arch.libdir
 
 def get_args(template):
-    argspec = inspect.getargspec(template.module.render_body)
-    return set(argspec.args[1:]) # skip "context"
+    sig = inspect.signature(template.module.render_body)
+    return set(list(sig.parameters)[1:]) # skip "context"
 
 def readtemplate(filename):
     parser = LoraxTemplate(directories=['.'])


### PR DESCRIPTION
Sometimes debugging a boot.iso requires using gdb, and finding the
corresponding debuginfo packages can be difficult. This writes the
matching -debuginfo package names and full ENVR to a file on the iso.
This can then be fed to dnf to install the correct debug packages.