### PR TITLE
Add --iso-only option to --make-iso

### DIFF
--- a/docs/livemedia-creator.1
+++ b/docs/livemedia-creator.1
@@ -5,7 +5,7 @@ livemedia-creator \- Create live install media
 .SH SYNOPSIS
 livemedia-creator [-h]
     (--make-iso | --make-disk | --make-fsimage | --make-appliance | --make-ami | --make-tar | --make-pxe-live | --make-ostree-live)
-    [--iso ISO] [--disk-image DISK_IMAGE]
+    [--iso ISO] [--iso-only] [--disk-image DISK_IMAGE]
     [--fs-image FS_IMAGE] [--ks KS]
     [--image-name IMAGE_NAME] [--image-only]
     [--fs-label FS_LABEL]
@@ -84,6 +84,10 @@ Build a live pxe boot squashfs image of Atomic Host
 .TP
 \fB\-\-iso ISO\fR
 Anaconda installation .iso path to use for virt-install
+
+.TP
+\fB\-\-iso-only\fR
+Remove all iso creation artifacts except the boot.iso, combine with --image-name to rename the boot.iso
 
 .TP
 \fB\-\-disk\-image DISK_IMAGE\fR

--- a/docs/livemedia-creator.rst
+++ b/docs/livemedia-creator.rst
@@ -101,6 +101,12 @@ Currently the standard lorax templates are used to make a bootable iso, but
 it should be possible to modify them to output other results. They are
 written using the Mako template system which is very flexible.
 
+.. note::
+    The output from --make-iso includes the artifacts used to create the boot.iso;
+    the kernel, initrd, the squashfs filesystem, etc. If you only want the
+    boot.iso you can pass ``--iso-only`` and the other files will be removed. You
+    can also name the iso by using ``--image-name my-live.iso``.
+
 
 Kickstarts
 ----------

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -563,7 +563,7 @@ def mount_boot_part_over_root(img_mount):
     """
     root_dir = img_mount.mount_dir
     is_boot_part = lambda dir: os.path.exists(dir+"/loader.0")
-    tmp_mount_dir = tempfile.mkdtemp()
+    tmp_mount_dir = tempfile.mkdtemp(prefix="lmc-tmpdir-")
     sys_root = find_ostree_root(root_dir)
     sysroot_boot_dir = None
     for dev, _size in img_mount.loop_devices:
@@ -723,7 +723,7 @@ def novirt_install(opts, disk_img, disk_size, repo_url):
         # convert the image to the selected format
         if "-O" not in qemu_args:
             qemu_args.extend(["-O", opts.image_type])
-        qemu_img = tempfile.mktemp(prefix="disk", suffix=".img")
+        qemu_img = tempfile.mktemp(prefix="lmc-disk-", suffix=".img")
         execWithRedirect("qemu-img", ["convert"] + qemu_args + [disk_img, qemu_img], raise_err=True)
         if not opts.make_vagrant:
             execWithRedirect("mv", ["-f", qemu_img, disk_img], raise_err=True)
@@ -733,7 +733,7 @@ def novirt_install(opts, disk_img, disk_size, repo_url):
             for arg in opts.compress_args:
                 compress_args += arg.split(" ", 1)
 
-            vagrant_dir = tempfile.mkdtemp()
+            vagrant_dir = tempfile.mkdtemp(prefix="lmc-tmpdir-")
             metadata_path = joinpaths(vagrant_dir, "metadata.json")
             execWithRedirect("mv", ["-f", qemu_img, joinpaths(vagrant_dir, "box.img")], raise_err=True)
             if opts.vagrant_metadata:
@@ -807,7 +807,7 @@ def virt_install(opts, install_log, disk_img, disk_size):
         mkqemu_img(disk_img, disk_size*1024**2, qemu_args)
 
     if opts.make_fsimage or opts.make_tar or opts.make_oci:
-        diskimg_path = tempfile.mktemp(prefix="disk", suffix=".img")
+        diskimg_path = tempfile.mktemp(prefix="lmc-disk-", suffix=".img")
     else:
         diskimg_path = disk_img
 
@@ -876,7 +876,7 @@ def virt_install(opts, install_log, disk_img, disk_size):
         for arg in opts.compress_args:
             compress_args += arg.split(" ", 1)
 
-        vagrant_dir = tempfile.mkdtemp()
+        vagrant_dir = tempfile.mkdtemp(prefix="lmc-tmpdir-")
         metadata_path = joinpaths(vagrant_dir, "metadata.json")
         execWithRedirect("mv", ["-f", disk_img, joinpaths(vagrant_dir, "box.img")], raise_err=True)
         if opts.vagrant_metadata:
@@ -941,7 +941,7 @@ def make_image(opts, ks):
     if opts.image_name:
         disk_img = joinpaths(opts.result_dir, opts.image_name)
     else:
-        disk_img = tempfile.mktemp(prefix="disk", suffix=".img", dir=opts.result_dir)
+        disk_img = tempfile.mktemp(prefix="lmc-disk-", suffix=".img", dir=opts.result_dir)
     log.info("disk_img = %s", disk_img)
 
     try:
@@ -1377,7 +1377,7 @@ def main():
     if not opts.image_only:
         result_dir = None
         if opts.make_iso:
-            work_dir = tempfile.mkdtemp()
+            work_dir = tempfile.mkdtemp(prefix="lmc-work-")
             log.info("working dir is %s", work_dir)
 
             if (opts.fs_image or opts.no_virt) and not opts.disk_image:
@@ -1422,7 +1422,7 @@ def main():
                            opts.app_template, opts.app_file, networks, opts.ram,
                            opts.vcpus or 1, opts.arch, opts.title, opts.project, opts.releasever)
         elif opts.make_pxe_live:
-            work_dir = tempfile.mkdtemp()
+            work_dir = tempfile.mkdtemp(prefix="lmc-work-")
             log.info("working dir is %s", work_dir)
 
             if opts.fs_image and not opts.disk_image:

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -1052,6 +1052,9 @@ def main():
 
     parser.add_argument("--iso", type=os.path.abspath,
                         help="Anaconda installation .iso path to use for virt-install")
+    parser.add_argument("--iso-only", action="store_true",
+                        help="Remove all iso creation artifacts except the boot.iso, "
+                             "combine with --image-name to rename the boot.iso")
     parser.add_argument("--ks", action="append", type=os.path.abspath,
                         help="Kickstart file defining the install.")
     parser.add_argument("--image-only", action="store_true",
@@ -1074,7 +1077,8 @@ def main():
 
     parser.add_argument("--logfile", default="./livemedia.log",
                         type=os.path.abspath,
-                        help="Path to logfile")
+                        help="Name and path for primary logfile, other logs will "
+                             "be created in the same directory.")
     parser.add_argument("--lorax-templates", default="/usr/share/lorax/",
                         type=os.path.abspath,
                         help="Path to mako templates for lorax")
@@ -1205,6 +1209,10 @@ def main():
         errors.append("The results_dir (%s) should not exist, please delete or "
                       "move its contents" % opts.result_dir)
 
+    # Default to putting results under tmp
+    if not opts.result_dir:
+        opts.result_dir = opts.tmp
+
     if opts.iso and not os.path.exists(opts.iso):
         errors.append("The iso %s is missing." % opts.iso)
 
@@ -1285,10 +1293,7 @@ def main():
         list(log.error(e) for e in errors)
         sys.exit(1)
 
-    # Default to putting results under tmp
-    if not opts.result_dir:
-        opts.result_dir = opts.tmp
-    else:
+    if not os.path.exists(opts.result_dir):
         os.makedirs(opts.result_dir)
 
     # AMI image is just a fsimage with an AMI label
@@ -1390,6 +1395,18 @@ def main():
                         make_runtime(opts, img_mount.mount_dir, work_dir)
                         result_dir = make_livecd(opts, img_mount.mount_dir, work_dir)
 
+            # --iso-only removes the extra build artifacts, keeping only the boot.iso
+            if opts.iso_only and result_dir:
+                boot_iso = joinpaths(result_dir, "images/boot.iso")
+                if not os.path.exists(boot_iso):
+                    log.error("%s is missing, skipping --iso-only.", boot_iso)
+                else:
+                    iso_dir = tempfile.mkdtemp(prefix="lmc-result-")
+                    dest_file = joinpaths(iso_dir, opts.image_name or "boot.iso")
+                    shutil.move(boot_iso, dest_file)
+                    shutil.rmtree(result_dir)
+                    result_dir = iso_dir
+
             # cleanup the mess
             # cleanup work_dir?
             if disk_img and not (opts.keep_image or opts.disk_image or opts.fs_image):
@@ -1435,8 +1452,9 @@ def main():
                                 umount(mounted_sysroot_boot_dir)
 
         if opts.result_dir != opts.tmp and result_dir:
-            copytree(result_dir, opts.result_dir)
+            copytree(result_dir, opts.result_dir, preserve=False)
             shutil.rmtree(result_dir)
+            result_dir = None
 
     log.info("SUMMARY")
     log.info("-------")
@@ -1445,7 +1463,7 @@ def main():
         log.info("Disk image is at %s", disk_img)
     if opts.make_appliance:
         log.info("Appliance description is in %s", opts.app_file)
-    log.info("Results are in %s", opts.result_dir)
+    log.info("Results are in %s", result_dir or opts.result_dir)
 
     sys.exit( 0 )
 


### PR DESCRIPTION
This option removes all the extra build artifacts from --make-iso,
leaving only the boot.iso

It also supports naming of the final iso with --image-name