### PR TITLE
Add --iso-name to use with --iso-only

### DIFF
--- a/docs/livemedia-creator.1
+++ b/docs/livemedia-creator.1
@@ -87,7 +87,7 @@ Anaconda installation .iso path to use for virt-install
 
 .TP
 \fB\-\-iso-only\fR
-Remove all iso creation artifacts except the boot.iso, combine with --image-name to rename the boot.iso
+Remove all iso creation artifacts except the boot.iso, combine with --iso-name to rename the boot.iso
 
 .TP
 \fB\-\-disk\-image DISK_IMAGE\fR

--- a/docs/livemedia-creator.rst
+++ b/docs/livemedia-creator.rst
@@ -105,7 +105,7 @@ written using the Mako template system which is very flexible.
     The output from --make-iso includes the artifacts used to create the boot.iso;
     the kernel, initrd, the squashfs filesystem, etc. If you only want the
     boot.iso you can pass ``--iso-only`` and the other files will be removed. You
-    can also name the iso by using ``--image-name my-live.iso``.
+    can also name the iso by using ``--iso-name my-live.iso``.
 
 
 Kickstarts

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -1054,7 +1054,9 @@ def main():
                         help="Anaconda installation .iso path to use for virt-install")
     parser.add_argument("--iso-only", action="store_true",
                         help="Remove all iso creation artifacts except the boot.iso, "
-                             "combine with --image-name to rename the boot.iso")
+                             "combine with --iso-name to rename the boot.iso")
+    parser.add_argument("--iso-name", default=None,
+                        help="Name of output iso file for --iso-only. Default is boot.iso")
     parser.add_argument("--ks", action="append", type=os.path.abspath,
                         help="Kickstart file defining the install.")
     parser.add_argument("--image-only", action="store_true",
@@ -1402,7 +1404,7 @@ def main():
                     log.error("%s is missing, skipping --iso-only.", boot_iso)
                 else:
                     iso_dir = tempfile.mkdtemp(prefix="lmc-result-")
-                    dest_file = joinpaths(iso_dir, opts.image_name or "boot.iso")
+                    dest_file = joinpaths(iso_dir, opts.iso_name or "boot.iso")
                     shutil.move(boot_iso, dest_file)
                     shutil.rmtree(result_dir)
                     result_dir = iso_dir


### PR DESCRIPTION
Instead of reusing --image-name add a new argument to name the iso. This
way the disk image can be given a unique name with --image-name and the
iso can be named something different.