### PR TITLE
Add rng-tools and start rngd.service by default (#1258516)

### DIFF
--- a/share/runtime-install.tmpl
+++ b/share/runtime-install.tmpl
@@ -107,6 +107,7 @@ installpkg mt-st smartmontools
 installpkg hdparm pcmciautils
 %endif
 installpkg libmlx4 rdma
+installpkg rng-tools
 
 ## translations & language packs
 installpkg python3-dnf-langpacks

--- a/share/runtime-postinstall.tmpl
+++ b/share/runtime-postinstall.tmpl
@@ -29,6 +29,9 @@ symlink /lib/systemd/system/anaconda.target etc/systemd/system/default.target
 mkdir etc/systemd/system/local-fs.target.wants/
 symlink /lib/systemd/system/tmp.mount etc/systemd/system/local-fs.target.wants/tmp.mount
 
+## Start rngd
+symlink /lib/systemd/system/rngd.service etc/systemd/system/basic.target.wants/rngd.service
+
 ## Disable unwanted systemd services
 systemctl disable systemd-readahead-collect.service \
                   systemd-readahead-replay.service \


### PR DESCRIPTION
This will help improve the entropy situation with non-x86 hardware. rngd
will add entropy from hardware rng sources.

Resolves: rhbz#1258516