### PR TITLE
livemedia-creator: Stop passing --repo to anaconda (#1304802)

### DIFF
--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -600,7 +600,7 @@ def novirt_log_check(log_check, proc):
     return False
 
 
-def novirt_install(opts, disk_img, disk_size, repo_url):
+def novirt_install(opts, disk_img, disk_size):
     """
     Use Anaconda to install to a disk image
 
@@ -608,7 +608,6 @@ def novirt_install(opts, disk_img, disk_size, repo_url):
     :type opts: argparse options
     :param str disk_img: The full path to the disk image to be created
     :param int disk_size: The size of the disk_img in MiB
-    :param str repo_url: The url of the repository to use for the installation
 
     This method makes sure SELinux is permissive during the install, runs anaconda
     to create the image and then based on the opts passed create a qemu disk image
@@ -628,7 +627,7 @@ def novirt_install(opts, disk_img, disk_size, repo_url):
         if os.path.isdir(path):
             shutil.rmtree(path)
 
-    args = ["--kickstart", opts.ks[0], "--cmdline", "--repo", repo_url]
+    args = ["--kickstart", opts.ks[0], "--cmdline"]
     if opts.anaconda_args:
         for arg in opts.anaconda_args:
             args += arg.split(" ", 1)
@@ -951,18 +950,7 @@ def make_image(opts, ks):
 
     try:
         if opts.no_virt:
-            method = ks.handler.method
-            if method.method == "url":
-                repo_url = method.url
-            elif method.method == "nfs":
-                if method.opts:
-                    repo_url = "nfs:%s:%s:%s" % (method.opts, method.server, method.dir)
-                else:
-                    repo_url = "nfs:%s:%s" % (method.server, method.dir)
-            else:
-                raise InstallError("Unsupported installation method: %s" % method.method)
-
-            novirt_install(opts, disk_img, disk_size, repo_url)
+            novirt_install(opts, disk_img, disk_size)
         else:
             install_log = os.path.abspath(os.path.dirname(opts.logfile))+"/virt-install.log"
             log.info("install_log = %s", install_log)


### PR DESCRIPTION
When running a no-virt installation it was parsing the kickstart url
method and passing it to anaconda using --repo which prevents it from
working with url --mirrorlist method. There is no good reason to do
this, anaconda gets the method directly from the kickstart when it isn't
on the cmdline.