### PR TITLE
Include grub2-efi-modules on the boot.iso (#1277227)

### DIFF
--- a/share/runtime-install.tmpl
+++ b/share/runtime-install.tmpl
@@ -20,7 +20,7 @@ installpkg kernel
 
 ## arch-specific packages (bootloaders etc.)
 %if basearch == "aarch64":
-    installpkg efibootmgr grub2-efi grubby shim shim-unsigned
+    installpkg efibootmgr grub2-efi grub2-efi-modules grubby shim shim-unsigned
 %endif
 %if basearch in ("arm", "armhfp"):
     installpkg kernel-lpae kernel-tegra
@@ -31,7 +31,7 @@ installpkg kernel
 %endif
 %if basearch in ("i386", "x86_64"):
     installpkg grub2 grub2-tools biosdevname memtest86+ syslinux
-    installpkg efibootmgr grub2-efi shim shim-unsigned
+    installpkg efibootmgr grub2-efi grub2-efi-modules shim shim-unsigned
 %endif
 %if basearch in ("ppc", "ppc64", "ppc64le"):
     installpkg grub2 grub2-tools fbset hfsutils kernel-bootwrapper ppc64-utils


### PR DESCRIPTION
Some users need to be able to run grub2-install from %pre

Resolves: rhbz#1277227