### PR TITLE
Keep modules needed for ast video driver support (#1272658)

### DIFF
--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -90,7 +90,7 @@ removekmod sound drivers/media drivers/hwmon \
 removekmod drivers/char --allbut virtio_console hw_random \
                                   virtio-rng ipmi
 removekmod drivers/staging --allbut zram
-removekmod drivers/video --allbut hyperv_fb
+removekmod drivers/video --allbut hyperv_fb syscopyarea sysfillrect sysimgblt
 remove lib/modules/*/{build,source,*.map}
 ## NOTE: depmod gets re-run after cleanup finishes
 


### PR DESCRIPTION
The ast module depends on:
drm,drm_kms_helper,ttm,syscopyarea,i2c-core,sysfillrect,sysimgblt,i2c-algo-bit

This retains the syscopyarea, sysfillrect, and sysimgblt modules.

Resolves: rhbz#1272658