### PR TITLE
Install the libblockdev-lvm-dbus plugin (#1264816)

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -84,6 +84,9 @@ installpkg system-storage-manager
 installpkg device-mapper-persistent-data
 installpkg xfsdump
 
+## extra libblockdev plugins
+installpkg libblockdev-lvm-dbus
+
 ## needed for LUKS escrow
 installpkg volume_key
 installpkg nss-tools


### PR DESCRIPTION
This will allow blivet to make use of the LVM DBus PoC API.