### PR TITLE
Add glibc-all-langpacks

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -24,6 +24,9 @@ installpkg grubby
     installpkg b43-openfwwf
 %endif
 
+## install all of the glibc langpacks since otherwise we get no locales
+installpkg glibc-all-langpacks
+
 ## arch-specific packages (bootloaders etc.)
 %if basearch == "aarch64":
     installpkg efibootmgr grub2-efi grub2-efi-modules grubby shim shim-unsigned


### PR DESCRIPTION
glibc recently split all of its locale data into subpackages, so if we
install no langpacks we get no locales. Explicitly install all of the
langpacks.

The boot.iso this spits out is about 20MB bigger than the last one from Jenkins, but I'm not sure if that's because of the langpacks or something else.