### PR TITLE
Not all arches currently have docker

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -160,7 +160,10 @@ installpkg gdisk hexedit sg3_utils
 installpkg notification-daemon
 
 ## Docker enabled boot.iso
-installpkg docker-anaconda-addon
+# Not all arches currently have docker
+%if basearch not in ("ppc", "ppc64", "s390", "s390x"):
+    installpkg docker-anaconda-addon
+%endif
 
 ## actually install all the requested packages
 run_pkg_transaction


### PR DESCRIPTION
At the momenet some PPC and s390 arches don't have docker, in that case we get the following failure when running lorax.

DEBUG util.py:417:  2016-03-12 01:00:27,658:   dnf.exceptions.DepsolveError: nothing provides docker-utils needed by docker-anaconda-addon-0.2-1.fc24.noarch
DEBUG util.py:417:    dnf.exceptions.DepsolveError: nothing provides docker-utils needed by docker-anaconda-addon-0.2-1.fc24.noarch
DEBUG util.py:417:  Traceback (most recent call last):
DEBUG util.py:417:    File "/usr/sbin/lorax", line 353, in <module>
DEBUG util.py:417:      main(sys.argv)
DEBUG util.py:417:    File "/usr/sbin/lorax", line 209, in main
DEBUG util.py:417:      remove_temp=True, verify=opts.verify)
DEBUG util.py:417:    File "/usr/lib/python3.5/site-packages/pylorax/__init__.py", line 277, in run
DEBUG util.py:417:      rb.install()
DEBUG util.py:417:    File "/usr/lib/python3.5/site-packages/pylorax/treebuilder.py", line 119, in install
DEBUG util.py:417:      self._runner.run("runtime-install.tmpl")
DEBUG util.py:417:    File "/usr/lib/python3.5/site-packages/pylorax/ltmpl.py", line 219, in run
DEBUG util.py:417:      self._run(commands)
DEBUG util.py:417:    File "/usr/lib/python3.5/site-packages/pylorax/ltmpl.py", line 238, in _run
DEBUG util.py:417:      f(*args)
DEBUG util.py:417:    File "/usr/lib/python3.5/site-packages/pylorax/ltmpl.py", line 540, in run_pkg_transaction
DEBUG util.py:417:      self.dbo.resolve()
DEBUG util.py:417:    File "/usr/lib/python3.5/site-packages/dnf/base.py", line 547, in resolve
DEBUG util.py:417:      raise exc
DEBUG util.py:417:  dnf.exceptions.DepsolveError: nothing provides docker-utils needed by docker-anaconda-addon-0.2-1.fc24.noarch
DEBUG util.py:542:  Child return code was: 1

Signed-off-by: Peter Robinson <pbrobinson@fedoraproject.org>