### PR TITLE
Create UDF iso when stage2 is >= 4GiB (#1312158)

### DIFF
--- a/share/templates.d/99-generic/aarch64.tmpl
+++ b/share/templates.d/99-generic/aarch64.tmpl
@@ -7,6 +7,16 @@ STAGE2IMG="images/install.img"
 LORAXDIR="usr/share/lorax/"
 %>
 
+## Test ${runtime_img} to see if udf is needed
+<%
+    import os
+    from pylorax.sysutils import joinpaths
+    if os.stat(joinpaths(outroot, runtime_img)).st_size >= 4*1024**3:
+        udfargs = "-allow-limited-size"
+    else:
+        udfargs = ""
+%>
+
 mkdir images
 install ${runtime_img} ${STAGE2IMG}
 treeinfo stage2 mainimage ${STAGE2IMG}
@@ -54,7 +64,8 @@ mkdir ${KERNELDIR}
 %if exists("boot/efi/EFI/*/gcdaa64.efi"):
 ## make boot.iso
 runcmd mkisofs -o ${outroot}/images/boot.iso \
-       ${efiargs} -R -J -V '${isolabel}' -T -graft-points \
+       ${efiargs} -R -J -V '${isolabel}' -T ${udfargs} \
+       -graft-points \
        ${KERNELDIR}=${outroot}/${KERNELDIR} \
        ${STAGE2IMG}=${outroot}/${STAGE2IMG} \
        ${efigraft} ${imggraft}

--- a/share/templates.d/99-generic/live/ppc.tmpl
+++ b/share/templates.d/99-generic/live/ppc.tmpl
@@ -20,6 +20,16 @@ prepboot = ""
 isolabel = ''.join(ch if ch.isalnum() else '_' for ch in isolabel)
 %>
 
+## Test ${runtime_img} to see if udf is needed
+<%
+    import os
+    from pylorax.sysutils import joinpaths
+    if os.stat(joinpaths(outroot, runtime_img)).st_size >= 4*1024**3:
+        udfargs = "-allow-limited-size"
+    else:
+        udfargs = ""
+%>
+
 mkdir ${LIVEDIR}
 install ${runtime_img} ${LIVEDIR}/squashfs.img
 treeinfo stage2 mainimage ${LIVEDIR}/squashfs.img
@@ -95,7 +105,8 @@ runcmd mkisofs -o ${outroot}/images/boot.iso -chrp-boot -U \
         -volset "${product.version}" -volset-size 1 -volset-seqno 1 \
         -hfs-volid ${product.version} -hfs-bless ${outroot}/${MACDIR} \
         -map ${inroot}/${configdir}/mapping \
-        -no-desktop -allow-multidot -graft-points \
+        -no-desktop -allow-multidot ${udfargs} \
+        -graft-points \
         ${BOOTDIR}=${outroot}/${BOOTDIR} \
         ${GRUBDIR}=${outroot}/${GRUBDIR} \
         ${NETBOOTDIR}=${outroot}/${NETBOOTDIR} \

--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -15,6 +15,16 @@ def valid_label(ch):
 isolabel = ''.join(ch if valid_label(ch) else '-' for ch in isolabel)
 %>
 
+## Test ${runtime_img} to see if udf is needed
+<%
+    import os
+    from pylorax.sysutils import joinpaths
+    if os.stat(joinpaths(outroot, runtime_img)).st_size >= 4*1024**3:
+        udfargs = "-allow-limited-size"
+    else:
+        udfargs = ""
+%>
+
 mkdir ${LIVEDIR}
 install ${runtime_img} ${LIVEDIR}/squashfs.img
 treeinfo stage2 mainimage ${LIVEDIR}/squashfs.img
@@ -87,7 +97,8 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 runcmd mkisofs -o ${outroot}/images/boot.iso \
        -b ${BOOTDIR}/isolinux.bin -c ${BOOTDIR}/boot.cat \
        -boot-load-size 4 -boot-info-table -no-emul-boot \
-       ${efiargs} -R -J -V '${isolabel}' -T -graft-points \
+       ${efiargs} -R -J -V '${isolabel}' -T ${udfargs} \
+       -graft-points \
        ${BOOTDIR}=${outroot}/${BOOTDIR} \
        ${KERNELDIR}=${outroot}/${KERNELDIR} \
        ${LIVEDIR}=${outroot}/${LIVEDIR} \

--- a/share/templates.d/99-generic/ppc.tmpl
+++ b/share/templates.d/99-generic/ppc.tmpl
@@ -23,6 +23,16 @@ isolabel = ''.join(ch if ch.isalnum() else '_' for ch in isolabel)
 rootarg = ""
 %>
 
+## Test ${runtime_img} to see if udf is needed
+<%
+    import os
+    from pylorax.sysutils import joinpaths
+    if os.stat(joinpaths(outroot, runtime_img)).st_size >= 4*1024**3:
+        udfargs = "-allow-limited-size"
+    else:
+        udfargs = ""
+%>
+
 mkdir images
 install ${runtime_img} ${STAGE2IMG}
 treeinfo stage2 mainimage ${STAGE2IMG}
@@ -105,7 +115,7 @@ runcmd mkisofs -o ${outroot}/images/boot.iso -chrp-boot -U \
         -volset "${product.version}" -volset-size 1 -volset-seqno 1 \
         -hfs-volid ${product.version} -hfs-bless ${outroot}/${MACDIR} \
         -map ${inroot}/${configdir}/mapping \
-        -no-desktop -allow-multidot -graft-points \
+        -no-desktop -allow-multidot ${udfargs} -graft-points \
         ${BOOTDIR}=${outroot}/${BOOTDIR} \
         ${GRUBDIR}=${outroot}/${GRUBDIR} \
         ${NETBOOTDIR}=${outroot}/${NETBOOTDIR} \

--- a/share/templates.d/99-generic/ppc64le.tmpl
+++ b/share/templates.d/99-generic/ppc64le.tmpl
@@ -16,6 +16,16 @@ isolabel = ''.join(ch if ch.isalnum() else '_' for ch in isolabel)
 rootarg = ""
 %>
 
+## Test ${runtime_img} to see if udf is needed
+<%
+    import os
+    from pylorax.sysutils import joinpaths
+    if os.stat(joinpaths(outroot, runtime_img)).st_size >= 4*1024**3:
+        udfargs = "-allow-limited-size"
+    else:
+        udfargs = ""
+%>
+
 mkdir images
 install ${runtime_img} ${STAGE2IMG}
 treeinfo stage2 mainimage ${STAGE2IMG}
@@ -82,7 +92,7 @@ runcmd mkisofs -v -U -J -R -T \
         -volset "${product.version}" -volset-size 1 -volset-seqno 1 \
         -hfs-volid ${product.version} \
         -chrp-boot -map ${inroot}/${configdir}/mapping \
-        -no-desktop -allow-multidot -graft-points \
+        -no-desktop -allow-multidot ${udfargs} -graft-points \
         ${BOOTDIR}=${outroot}/${BOOTDIR} \
         ${GRUBDIR}=${outroot}/${GRUBDIR} \
         ${STAGE2IMG}=${outroot}/${STAGE2IMG} ${imggraft}

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -15,6 +15,16 @@ def valid_label(ch):
 isolabel = ''.join(ch if valid_label(ch) else '-' for ch in isolabel)
 %>
 
+## Test ${runtime_img} to see if udf is needed
+<%
+    import os
+    from pylorax.sysutils import joinpaths
+    if os.stat(joinpaths(outroot, runtime_img)).st_size >= 4*1024**3:
+        udfargs = "-allow-limited-size"
+    else:
+        udfargs = ""
+%>
+
 mkdir images
 install ${runtime_img} ${STAGE2IMG}
 treeinfo stage2 mainimage images/${runtime_base}
@@ -96,7 +106,8 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 runcmd mkisofs -o ${outroot}/images/boot.iso \
        -b ${BOOTDIR}/isolinux.bin -c ${BOOTDIR}/boot.cat \
        -boot-load-size 4 -boot-info-table -no-emul-boot \
-       ${efiargs} -R -J -V '${isolabel}' -T -graft-points \
+       ${efiargs} -R -J -V '${isolabel}' -T ${udfargs} \
+       -graft-points \
        ${STAGE2IMG}=${outroot}/${STAGE2IMG} \
        ${BOOTDIR}=${outroot}/${BOOTDIR} \
        ${KERNELDIR}=${outroot}/${KERNELDIR} \


### PR DESCRIPTION
Some images are becoming REALLY large. When a file is >= 4GiB we need to
pass -allow-limited-size to mkisofs to tell it to make a UDF image. Note
that the manpage says that this may result in it not booting on all
systems.