### PR TITLE
templates: Fix runtime_img check

### DIFF
--- a/share/templates.d/99-generic/aarch64.tmpl
+++ b/share/templates.d/99-generic/aarch64.tmpl
@@ -1,4 +1,4 @@
-<%page args="kernels, runtime_img, basearch, outroot, product, isolabel"/>
+<%page args="kernels, runtime_img, basearch, inroot, outroot, product, isolabel"/>
 <%
 configdir="tmp/config_files/aarch64"
 PXEBOOTDIR="images/pxeboot"
@@ -11,7 +11,7 @@ LORAXDIR="usr/share/lorax/"
 <%
     import os
     from pylorax.sysutils import joinpaths
-    if os.stat(joinpaths(outroot, runtime_img)).st_size >= 4*1024**3:
+    if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
         udfargs = "-allow-limited-size"
     else:
         udfargs = ""

--- a/share/templates.d/99-generic/live/ppc.tmpl
+++ b/share/templates.d/99-generic/live/ppc.tmpl
@@ -24,7 +24,7 @@ isolabel = ''.join(ch if ch.isalnum() else '_' for ch in isolabel)
 <%
     import os
     from pylorax.sysutils import joinpaths
-    if os.stat(joinpaths(outroot, runtime_img)).st_size >= 4*1024**3:
+    if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
         udfargs = "-allow-limited-size"
     else:
         udfargs = ""

--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -1,4 +1,4 @@
-<%page args="kernels, runtime_img, basearch, outroot, product, isolabel"/>
+<%page args="kernels, runtime_img, basearch, inroot, outroot, product, isolabel"/>
 <%
 configdir="tmp/config_files/x86"
 SYSLINUXDIR="usr/share/syslinux"
@@ -19,7 +19,7 @@ isolabel = ''.join(ch if valid_label(ch) else '-' for ch in isolabel)
 <%
     import os
     from pylorax.sysutils import joinpaths
-    if os.stat(joinpaths(outroot, runtime_img)).st_size >= 4*1024**3:
+    if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
         udfargs = "-allow-limited-size"
     else:
         udfargs = ""

--- a/share/templates.d/99-generic/ppc.tmpl
+++ b/share/templates.d/99-generic/ppc.tmpl
@@ -27,7 +27,7 @@ rootarg = ""
 <%
     import os
     from pylorax.sysutils import joinpaths
-    if os.stat(joinpaths(outroot, runtime_img)).st_size >= 4*1024**3:
+    if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
         udfargs = "-allow-limited-size"
     else:
         udfargs = ""

--- a/share/templates.d/99-generic/ppc64le.tmpl
+++ b/share/templates.d/99-generic/ppc64le.tmpl
@@ -20,7 +20,7 @@ rootarg = ""
 <%
     import os
     from pylorax.sysutils import joinpaths
-    if os.stat(joinpaths(outroot, runtime_img)).st_size >= 4*1024**3:
+    if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
         udfargs = "-allow-limited-size"
     else:
         udfargs = ""

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -1,4 +1,4 @@
-<%page args="kernels, runtime_img, runtime_base, basearch, outroot, product, isolabel"/>
+<%page args="kernels, runtime_img, runtime_base, basearch, inroot, outroot, product, isolabel"/>
 <%
 configdir="tmp/config_files/x86"
 SYSLINUXDIR="usr/share/syslinux"
@@ -19,7 +19,7 @@ isolabel = ''.join(ch if valid_label(ch) else '-' for ch in isolabel)
 <%
     import os
     from pylorax.sysutils import joinpaths
-    if os.stat(joinpaths(outroot, runtime_img)).st_size >= 4*1024**3:
+    if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
         udfargs = "-allow-limited-size"
     else:
         udfargs = ""


### PR DESCRIPTION
commit 66241f7cd72a25317dece91d15bf6e30538b9a08 added a check on
runtime_img to create UDF iso's. Ends up it is only in outroot for live,
so switch all the checks to look at it in inroot instead.