### PR TITLE
livemedia-creator: Simplify cleanup for no-virt

### DIFF
--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -672,6 +672,23 @@ def novirt_log_check(log_check, proc):
     return False
 
 
+def anaconda_cleanup(dirinstall_path):
+    """
+    Cleanup any leftover mounts from anaconda
+
+    :param str dirinstall_path: Path where anaconda mounts things
+
+    If anaconda crashes it may leave things mounted under this path. It will
+    typically be set to /mnt/sysimage/
+    """
+    dirinstall_path = os.path.abspath(dirinstall_path)
+    # unmount filesystems
+    for mounted in reversed(open("/proc/mounts").readlines()):
+        (_device, mountpoint, _rest) = mounted.split(" ", 2)
+        if mountpoint.startswith(dirinstall_path):
+            umount(mountpoint)
+
+
 def novirt_install(opts, disk_img, disk_size):
     """
     Use Anaconda to install to a disk image
@@ -754,8 +771,8 @@ def novirt_install(opts, disk_img, disk_size):
     finally:
         log_monitor.shutdown()
 
-        # If anaconda failed there may be things needing cleanup
-        execWithRedirect("anaconda-cleanup", [])
+        # Make sure any leftover anaconda mounts have been cleaned up
+        anaconda_cleanup(dirinstall_path)
 
         # Move the anaconda logs over to a log directory
         log_dir = os.path.abspath(os.path.dirname(opts.logfile))


### PR DESCRIPTION
If an anaconda no-virt run crashes it can leave things mounted under
/mnt/sysimage. Previously anaconda-cleanup was used to handle this, but
it will also try to cleanup host mountpoints which isn't desired.