### PR TITLE
Create an empty selinux config file (#1332147)

### DIFF
--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -25,6 +25,11 @@ removefrom dracut --allbut /usr/lib/dracut/modules.d/30convertfs/convertfs.sh \
                   /usr/lib/dracut/dracut-initramfs-restore
 ## we don't run SELinux (not in enforcing, anyway)
 removepkg checkpolicy selinux-policy libselinux-utils
+
+## selinux checks for the /etc/selinux/config file's existance
+## The removepkg above removes it, create an empty one. See rhbz#1243168
+append etc/selinux/config ""
+
 ## anaconda has its own repo files
 removefrom fedora-release --allbut /etc/os-release
 removepkg fedora-release-rawhide

--- a/share/runtime-postinstall.tmpl
+++ b/share/runtime-postinstall.tmpl
@@ -63,9 +63,6 @@ mkdir etc/NetworkManager/conf.d
 install ${configdir}/90-anaconda-no-auto-default.conf etc/NetworkManager/conf.d
 install ${configdir}/91-anaconda-autoconnect-slaves.conf etc/NetworkManager/conf.d
 install ${configdir}/92-anaconda-loglevel-debug.conf etc/NetworkManager/conf.d
-%if exists(root+"/etc/selinux/targeted"):
-    install ${configdir}/selinux.config etc/selinux/config
-%endif
 install ${configdir}/vconsole.conf etc
 
 ## set up sshd


### PR DESCRIPTION
In order for selinux to properly label the system it needs to see that
the config file exists.

Also remove the old code trying to copy in a selinux config file, it
never worked -- the removepkg would remove it.

(cherry picked from commit d6584e1d7735cd181ae3cced839bf1118ec0e0ad)

Resolves: rhbz#1332147