### PR TITLE
Add efi, product, and updates image paths to treeinfo

### DIFF
--- a/share/templates.d/99-generic/aarch64.tmpl
+++ b/share/templates.d/99-generic/aarch64.tmpl
@@ -5,6 +5,8 @@ PXEBOOTDIR="images/pxeboot"
 KERNELDIR=PXEBOOTDIR
 STAGE2IMG="images/install.img"
 LORAXDIR="usr/share/lorax/"
+
+from os.path import basename
 %>
 
 ## Test ${runtime_img} to see if udf is needed
@@ -38,10 +40,14 @@ mkdir ${KERNELDIR}
     efiarch = 'AA64'
     efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
     images = ["images/efiboot.img"]
-    for img in images:
+    %>
+    %for img in images:
+        <%
         efiargs += " -eltorito-alt-boot -e {0} -no-emul-boot".format(img)
         efigraft += " {0}={1}/{0}".format(img,outroot)
-    %>
+        %>
+        treeinfo images-${basearch} ${img|basename} ${img}
+    %endfor
     <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel"/>
 %endif
 
@@ -50,6 +56,7 @@ mkdir ${KERNELDIR}
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${LORAXDIR}/${img}/ images/${img}.img
+        treeinfo images-${basearch} ${img}.img images/${img}.img
         <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor

--- a/share/templates.d/99-generic/arm.tmpl
+++ b/share/templates.d/99-generic/arm.tmpl
@@ -44,6 +44,7 @@ treeinfo ${basearch} platforms ${platforms}
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg --xz -9 --memlimit-compress=3700MiB ${LORAXDIR}/${img}/ images/${img}.img
+        treeinfo images-${basearch} ${img}.img images/${img}.img
     %endif
 %endfor
 

--- a/share/templates.d/99-generic/live/arm.tmpl
+++ b/share/templates.d/99-generic/live/arm.tmpl
@@ -37,6 +37,7 @@ mkdir ${KERNELDIR}
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg --xz -9 --memlimit-compress=3700MiB ${LORAXDIR}/${img}/ images/${img}.img
+        treeinfo images-${basearch} ${img}.img images/${img}.img
     %endif
 %endfor
 

--- a/share/templates.d/99-generic/live/ppc.tmpl
+++ b/share/templates.d/99-generic/live/ppc.tmpl
@@ -94,6 +94,7 @@ install ${configdir}/mapping ${BOOTDIR}
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${LORAXDIR}/${img}/ images/${img}.img
+        treeinfo images-${basearch} ${img}.img images/${img}.img
         <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor

--- a/share/templates.d/99-generic/live/s390.tmpl
+++ b/share/templates.d/99-generic/live/s390.tmpl
@@ -38,6 +38,7 @@ treeinfo images-${basearch} generic.ins generic.ins
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${LORAXDIR}/${img}/ images/${img}.img
+        treeinfo images-${basearch} ${img}.img images/${img}.img
         <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor

--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -13,6 +13,8 @@ def valid_label(ch):
     return ch.isalnum() or ch == '_'
 
 isolabel = ''.join(ch if valid_label(ch) else '-' for ch in isolabel)
+
+from os.path import basename
 %>
 
 ## Test ${runtime_img} to see if udf is needed
@@ -76,11 +78,15 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
     images = ["images/efiboot.img"]
     if domacboot:
         images.append("images/macboot.img")
-    for img in images:
+    %>
+    %for img in images:
+        <%
         efiargs += " -eltorito-alt-boot -e {0} -no-emul-boot".format(img)
         efigraft += " {0}={1}/{0}".format(img,outroot)
-    efihybrid = "--uefi --mac" if domacboot else "--uefi"
-    %>
+        %>
+        treeinfo images-${basearch} ${img|basename} ${img}
+    %endfor
+    <% efihybrid = "--uefi --mac" if domacboot else "--uefi" %>
     <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel"/>
 %endif
 
@@ -93,6 +99,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${compressargs} ${LORAXDIR}/${img}/ images/${img}.img
+        treeinfo images-${basearch} ${img}.img images/${img}.img
         <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor

--- a/share/templates.d/99-generic/ppc.tmpl
+++ b/share/templates.d/99-generic/ppc.tmpl
@@ -97,6 +97,7 @@ install ${configdir}/mapping ${BOOTDIR}
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${LORAXDIR}/${img}/ images/${img}.img
+        treeinfo images-${basearch} ${img}.img images/${img}.img
         <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor

--- a/share/templates.d/99-generic/ppc64le.tmpl
+++ b/share/templates.d/99-generic/ppc64le.tmpl
@@ -73,6 +73,7 @@ mkdir images/
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${LORAXDIR}/${img}/ images/${img}.img
+        treeinfo images-${basearch} ${img}.img images/${img}.img
         <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor

--- a/share/templates.d/99-generic/s390.tmpl
+++ b/share/templates.d/99-generic/s390.tmpl
@@ -40,6 +40,7 @@ treeinfo images-${basearch} generic.ins generic.ins
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${LORAXDIR}/${img}/ images/${img}.img
+        treeinfo images-${basearch} ${img}.img images/${img}.img
         <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -13,6 +13,8 @@ def valid_label(ch):
     return ch.isalnum() or ch == '_'
 
 isolabel = ''.join(ch if valid_label(ch) else '-' for ch in isolabel)
+
+from os.path import basename
 %>
 
 ## Test ${runtime_img} to see if udf is needed
@@ -78,11 +80,15 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
     images = ["images/efiboot.img"]
     if domacboot:
         images.append("images/macboot.img")
-    for img in images:
+    %>
+    %for img in images:
+        <%
         efiargs += " -eltorito-alt-boot -e {0} -no-emul-boot".format(img)
         efigraft += " {0}={1}/{0}".format(img,outroot)
-    efihybrid = "--uefi --mac" if domacboot else "--uefi"
-    %>
+        %>
+        treeinfo images-${basearch} ${img|basename} ${img}
+    %endfor
+    <% efihybrid = "--uefi --mac" if domacboot else "--uefi" %>
     <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel"/>
 %endif
 
@@ -95,6 +101,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${compressargs} ${LORAXDIR}/${img}/ images/${img}.img
+        treeinfo images-${basearch} ${img}.img images/${img}.img
         <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor


### PR DESCRIPTION
Include the information about efiboot.img, macboot.img, product.img, and
updates.img in .treeinfo.