### PR TITLE
Keep fsfreeze in install environment (#1315468)

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -311,7 +311,7 @@ removefrom util-linux --allbut \
     /usr/bin/{dmesg,getopt,kill,login,lsblk,more,mount,umount,mountpoint,findmnt} \
     /etc/mtab /etc/pam.d/login /etc/pam.d/remote \
     /usr/sbin/{agetty,blkid,blockdev,clock,fdisk,fsck,fstrim,hwclock,losetup} \
-    /usr/sbin/{mkswap,nologin,sfdisk,swapoff,swapon,wipefs,partx} \
+    /usr/sbin/{mkswap,nologin,sfdisk,swapoff,swapon,wipefs,partx,fsfreeze} \
     /usr/bin/{logger,hexdump,flock}
 removefrom volume_key-libs /usr/share/locale/*
 removefrom wget /etc/* /usr/share/locale/*


### PR DESCRIPTION
The latest POWER platform allows a host machine to configure guests
running in a different endian mode. Guests configured in this way may
have their bootloader configuration file corrupted after installation if
the file was not fully written to disk. The host machine would read the
journal and try to finish writing the file in the wrong endian mode.

Issuing an fsfreeze and unfreeze gives more assurance that the
configuration file is properly written before a reboot; this patch adds
fsfreeze to the installer runtime environment.

Related: rhbz#1315468
