### PR TITLE
Add back libraries needed by spice-vdagent

### DIFF
--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -10,7 +10,8 @@ remove usr/share/i18n
     removepkg perl*
 %endif
 ## no sound support, thanks
-removepkg alsa* flac gstreamer-tools libsndfile pulseaudio* sound-theme-freedesktop
+## ...except alsa-libs, which are needed by spice-vdagent
+removepkg alsa-*firmware* flac gstreamer-tools libsndfile pulseaudio* sound-theme-freedesktop
 removepkg midisport-firmware
 ## no fancy video, either
 removepkg libcrystalhd crystalhd-firmware ivtv-firmware cx18-firmware


### PR DESCRIPTION
spice-vdagent, half of the thing that lets copy/paste work across a
spice connection, added sound support, I guess, so now we need
alsa-libs.

(cherry picked from commit 89441cd6752a97ce2ef62438a015e452f1421f77)

Resolves: rhbz#1347737