### PR TITLE
Make sure cmdline config file exists (#1348304)

### DIFF
--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -64,6 +64,8 @@ def main():
         os.makedirs(os.path.dirname(opts.logfile))
     if opts.sharedir and not os.path.isdir(opts.sharedir):
         parser.error("sharedir %s doesn't exist." % opts.sharedir)
+    if opts.config and not os.path.exists(opts.config):
+        parser.error("config file %s doesn't exist." % opts.config)
 
     setup_logging(opts)
 


### PR DESCRIPTION
If the --config file doesn't exist lorax will fall back to its defaults,
which are probably not what you want. Now it will exit if it doesn't
exist.