### PR TITLE
Keep all of the kernel drivers/target/ modules (#1348381)

### DIFF
--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -84,7 +84,7 @@ remove /usr/share/icons/*/icon-theme.cache
 removekmod sound drivers/media drivers/hwmon \
            net/atm net/bluetooth net/sched net/sctp \
            net/rds net/l2tp net/decnet net/netfilter net/ipv4 net/ipv6 \
-           drivers/watchdog drivers/target drivers/rtc drivers/input/joystick \
+           drivers/watchdog drivers/rtc drivers/input/joystick \
            drivers/bluetooth drivers/hid drivers/edac \
            drivers/usb/serial drivers/usb/host drivers/usb/misc \
            fs/ocfs2 fs/ceph fs/nfsd fs/ubifs fs/nilfs2 \


### PR DESCRIPTION
The ib_srpt, and ib_isert modules depend on these.

Resolves: rhbz#1348381