### PR TITLE
Install storaged-iscsi to the runtime (#1347415)

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -93,6 +93,9 @@ installpkg system-storage-manager
 installpkg device-mapper-persistent-data
 installpkg xfsdump
 
+## extra storage packages
+installpkg storaged storaged-iscsi
+
 ## extra libblockdev plugins
 installpkg libblockdev-lvm-dbus
 


### PR DESCRIPTION
Blivet now needs it to work with iSCSI (with the iSCSI support being optional in
Blivet).