### PR TITLE
Fix aarch64 installs due to missing/unsupported packages

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -3,7 +3,9 @@
 
 ## anaconda package
 installpkg anaconda anaconda-widgets
+%if basearch != "aarch64":
 installpkg kexec-tools-anaconda-addon
+%endif
 ## anaconda deps that aren't in the RPM
 installpkg tmux
 ## for anaconda crash handling
@@ -115,8 +117,9 @@ installpkg bridge-utils
 ## hardware utilities/libraries
 installpkg pciutils usbutils ipmitool
 installpkg mt-st smartmontools
-%if basearch != "s390x":
-installpkg hdparm pcmciautils
+installpkg hdparm
+%if basearch not in ("aarch64", "s390x"):
+installpkg pcmciautils
 %endif
 installpkg libmlx4 rdma
 installpkg rng-tools


### PR DESCRIPTION
With commit fe17f97 changing the default from optional to required there's
a few packages that aren't currently supported on aarch64 that break the
compose. In particular aarch64 currently still doesn't have kexec, with luck
that might change in the F-25 cycle but until it does we need to have an
exception.

Signed-off-by: Peter Robinson <pbrobinson@fedoraproject.org>