### PR TITLE
livemedia-creator: Use hd:LABEL for stage2 iso (#1355882)

### DIFF
--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -299,7 +299,7 @@ class VirtualInstall( object ):
         if kernel_args:
             extra_args += " "+kernel_args
         if iso.liveos:
-            extra_args += " stage2=live:CDLABEL={0}".format(udev_escape(iso.label))
+            extra_args += " stage2=hd:LABEL={0}".format(udev_escape(iso.label))
         args.append("--extra-args")
         args.append(extra_args)
 


### PR DESCRIPTION
The correct way with the current dracut (and it should be backwards
compatible) is to reference it as stage2=hd:LABEL=...

(cherry picked from commit 4bc4b4c5a50c595e3dbe27fe530d27b8bd46faba)
Resolves: rhbz#1355882