### PR TITLE
Use size=10 by default

### DIFF
--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -166,7 +166,7 @@ class Lorax(BaseLoraxClass):
             isfinal=False, workdir=None, outputdir=None, buildarch=None, volid=None,
             domacboot=True, doupgrade=True, remove_temp=False,
             installpkgs=None,
-            size=2,
+            size=10,
             add_templates=None,
             add_template_vars=None,
             add_arch_templates=None,


### PR DESCRIPTION
I'm working on
https://fedoraproject.org/wiki/Changes/WorkstationOstree and when
using lorax to make an installer ISO with content embedded, I run out
of disk space since the desktop+various apps is large.

Since this ends up being compressed anyways, let's just bump the
currently arbitrary `2` to `10` - the only real cost I can think of is
going to be a few more superblock entries.