### PR TITLE
Don't install python3-dnf-langpacks

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -124,9 +124,6 @@ installpkg pcmciautils
 installpkg libmlx4 rdma
 installpkg rng-tools
 
-## translations & language packs
-installpkg python3-dnf-langpacks
-
 ## fonts & themes
 installpkg bitmap-fangsongti-fonts
 installpkg dejavu-sans-fonts dejavu-sans-mono-fonts


### PR DESCRIPTION
The package has been retired [1] and anaconda no longer needs it.

[1]
http://pkgs.fedoraproject.org/cgit/rpms/dnf-langpacks.git/commit/?id=51922797be2e6157582b86580b9898e146291245