### PR TITLE
templates fixes for alternate architectures

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -118,7 +118,7 @@ installpkg bridge-utils
 installpkg pciutils usbutils ipmitool
 installpkg mt-st smartmontools
 installpkg hdparm
-%if basearch not in ("aarch64", "s390x"):
+%if basearch not in ("aarch64", "ppc64le", "s390x"):
 installpkg pcmciautils
 %endif
 installpkg libmlx4 rdma

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -37,7 +37,7 @@ installpkg glibc-all-langpacks
 
 ## arch-specific packages (bootloaders etc.)
 %if basearch == "aarch64":
-    installpkg efibootmgr grub2-efi grub2-efi-modules grubby shim shim-unsigned
+    installpkg efibootmgr grub2-efi grub2-efi-modules grub2-tools shim shim-unsigned
 %endif
 %if basearch in ("arm", "armhfp"):
     installpkg kernel-lpae

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -166,7 +166,7 @@ installpkg notification-daemon
 
 ## Docker enabled boot.iso
 # Not all arches currently have docker
-%if basearch not in ("ppc", "ppc64", "s390", "s390x"):
+%if basearch not in ("ppc", "ppc64", "s390"):
     installpkg docker-anaconda-addon
 %endif
 


### PR DESCRIPTION
So a few minor fixes for changes in package sets for Alt Arches. The ppc64le patch is fallout from the change of default optional to requires (should be the last with luck) and is needed for Fedora 25 alpha to get a successful compose on ppc64le