### PR TITLE
Add ppc64le kernel path (#1374609)

### DIFF
--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -204,9 +204,8 @@ class IsoMountpoint(object):
         else:
             self.mount_dir = self.initrd_path
 
-        self.kernel = self.mount_dir+"/isolinux/vmlinuz"
-        self.initrd = self.mount_dir+"/isolinux/initrd.img"
-
+        kernel_list = [("/isolinux/vmlinuz", "/isolinux/initrd.img"),
+                       ("/ppc/ppc64/vmlinuz", "/ppc/ppc64/initrd.img")]
         if os.path.isdir( self.mount_dir+"/repodata" ):
             self.repo = self.mount_dir
         else:
@@ -214,9 +213,15 @@ class IsoMountpoint(object):
         self.liveos = os.path.isdir( self.mount_dir+"/LiveOS" )
 
         try:
-            for f in [self.kernel, self.initrd]:
-                if not os.path.isfile(f):
-                    raise Exception("Missing file on iso: {0}".format(f))
+            for kernel, initrd in kernel_list:
+                if (os.path.isfile(self.mount_dir+kernel) and
+                    os.path.isfile(self.mount_dir+initrd)):
+                    self.kernel = self.mount_dir+kernel
+                    self.initrd = self.mount_dir+initrd
+                    break
+            else:
+                raise Exception("Missing kernel and initrd file in iso, failed"
+                                " to search under: {0}".format(kernel_list))
         except:
             self.umount()
             raise


### PR DESCRIPTION
https://github.com/CentOS/sig-cloud-instance-build project is using livemedia-creator utility to create image but it is failing due to kernel and initrd files are checked in /isolinux folder. Centos7 ppc64le platform iso contains kernel and initrd under ppc/ppc64 folder, so added code to check in both the folder else fail as usual.

```
[root@rhel72 docker]# ./containerbuild.sh centos-7ppc64le.ks
2016-08-19 11:58:08,435: disk_size = 3GB
2016-08-19 11:58:08,436: disk_img = /var/tmp/centos-7ppc64le-docker.tar.xz
2016-08-19 11:58:08,436: install_log = /tmp/virt-install.log
mount: /dev/loop2 is write-protected, mounting read-only
ERROR    Host does not support any virtualization options 
Traceback (most recent call last):
  File "/usr/sbin/livemedia-creator", line 1284, in <module>
    disk_img = make_image(opts, ks)
  File "/usr/sbin/livemedia-creator", line 904, in make_image
    virt_install(opts, install_log, disk_img, disk_size)
  File "/usr/sbin/livemedia-creator", line 836, in virt_install
    qcow2=opts.qcow2)
  File "/usr/sbin/livemedia-creator", line 324, in __init__
    raise Exception("Problem starting virtual install")
Exception: Problem starting virtual install

real    0m0.552s
user    0m0.404s
sys 0m0.130s
mv: cannot stat ‘/var/tmp/centos-7ppc64le-docker.tar.xz’: No such file or directory
[root@rhel72 docker]#
```
