### PR TITLE
lorax: Add --rootfs-size (#1368743)

### DIFF
--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -166,7 +166,7 @@ class Lorax(BaseLoraxClass):
             isfinal=False, workdir=None, outputdir=None, buildarch=None, volid=None,
             domacboot=True, doupgrade=True, remove_temp=False,
             installpkgs=None,
-            size=10,
+            size=2,
             add_templates=None,
             add_template_vars=None,
             add_arch_templates=None,

--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -105,6 +105,8 @@ def lorax_parser():
                           metavar="[repo]", help="Names of repos to enable")
     optional.add_argument("--disablerepo", action="append", default=[], dest="disablerepos",
                           metavar="[repo]", help="Names of repos to disable")
+    optional.add_argument("--rootfs-size", type=int, default=2,
+                          help="Size of root filesystem in GiB. Defaults to 2.")
 
     # add the show version option
     parser.add_argument("-V", help="show program's version number and exit",

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -125,6 +125,7 @@ def main():
               workdir=tempdir, outputdir=opts.outputdir, buildarch=opts.buildarch,
               volid=opts.volid, domacboot=opts.domacboot, doupgrade=opts.doupgrade,
               installpkgs=opts.installpkgs,
+              size=opts.rootfs_size,
               add_templates=opts.add_templates,
               add_template_vars=parsed_add_template_vars,
               add_arch_templates=opts.add_arch_templates,


### PR DESCRIPTION
This controls how big the root filesystem is for the squashfs used in the boot.iso, the default is 2GiB.
    
Note that larger rootfs sizes will require more memory and may cause the build to fail.
