### PR TITLE
templates: Enusre basic.target.wants dir exists for rngd

### DIFF
--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -30,6 +30,7 @@ mkdir etc/systemd/system/local-fs.target.wants/
 symlink /lib/systemd/system/tmp.mount etc/systemd/system/local-fs.target.wants/tmp.mount
 
 ## Start rngd
+mkdir etc/systemd/system/basic.target.wants/
 symlink /lib/systemd/system/rngd.service etc/systemd/system/basic.target.wants/rngd.service
 
 ## Disable unwanted systemd services


### PR DESCRIPTION
There's something racy here; in my Atomic Workstation CI/CD I'm seeing:

```
01:12:43   symlink /lib/systemd/system/rngd.service etc/systemd/system/basic.target.wants/rngd.service
01:12:43   FileNotFoundError: [Errno 2] No such file or directory: '/lib/systemd/system/rngd.service' -> '/var/tmp/lorax.7cgdtz1_/installtree/etc/systemd/system/basic.target.wants/rngd.service'
```

Rather than debug this right now, let's just make sure it exists,
like we do right above for `tmp.mount`.