### PR TITLE
livemedia-creator: Check for packaging failures in the logs (#1374809)

### DIFF
--- a/src/pylorax/monitor.py
+++ b/src/pylorax/monitor.py
@@ -108,6 +108,7 @@ class LogRequestHandler(socketserver.BaseRequestHandler):
                         "traceback script(s) have been run",
                         "crashed on signal",
                         "packaging: Missed: NoSuchPackage",
+                        "packaging: Installation failed",
                         "The following error occurred while installing.  This is a fatal error"]
         re_tests =     [r"packaging: base repo .* not valid",
                         r"packaging: .* requires .*"]


### PR DESCRIPTION
anaconda-26.1 changed how package scriptlet failures are handled. They
are now fatal, and anaconda hangs after logging an Installation failure.

ERR packaging: Installation failed: PayloadInstallError('DNF error:
Non-fatal POSTIN scriptlet failure in rpm package mlocate',)

Catch this (the 'packaging: Installation failed' part) and terminate the
image creation.