### PR TITLE
Make sure dir for rngd exists [BZ#1377430]

### DIFF
--- a/share/runtime-postinstall.tmpl
+++ b/share/runtime-postinstall.tmpl
@@ -27,6 +27,7 @@ mkdir etc/systemd/system/local-fs.target.wants/
 symlink /lib/systemd/system/tmp.mount etc/systemd/system/local-fs.target.wants/tmp.mount
 
 ## Start rngd
+mkdir etc/systemd/system/basic.target.wants/
 symlink /lib/systemd/system/rngd.service etc/systemd/system/basic.target.wants/rngd.service
 
 ## Disable unwanted systemd services


### PR DESCRIPTION
It is good to ensure that dir exists before doing anything with it.

Currently it works with C7.2 just because there are `firewalld` inside anaconda chroot, which creates this dir :D
Also, firewalld is pulled not by `.tmpl`, but by indirect dependencies, so, it is not very reliable.

https://bugzilla.redhat.com/show_bug.cgi?id=1377430
