### PR TITLE
drop ssh server key generation for s390(x)

### DIFF
--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -87,15 +87,6 @@ append etc/shadow "install::14438:0:99999:7:::"
 ## remove root password
 replace "root:\*:" "root::" etc/shadow
 
-## s390-specific setup
-%if basearch in ("s390", "s390x"):
-    ## generate ssh keys
-    runcmd ssh-keygen -q -C "" -N "" -t rsa  -f ${root}/etc/ssh/ssh_host_rsa_key
-    runcmd ssh-keygen -q -C "" -N "" -t dsa  -f ${root}/etc/ssh/ssh_host_dsa_key
-    chmod etc/ssh/ssh_host*_key 600
-    chmod etc/ssh/ssh_host*_key.pub 644
-%endif
-
 ## gconf settings
 gconfset /desktop/gnome/interface/accessibility bool true
 


### PR DESCRIPTION
Let the keys to be created during runtime as on other arches.