### PR TITLE
templates: When a subprocess fatallly errors, output its stderr directly

### DIFF
--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -518,8 +518,8 @@ class LoraxTemplateRunner(object):
             logger.debug("command finished successfully")
         except CalledProcessError as e:
             if e.output:
-                logger.debug('command output:\n%s', e.output)
-            logger.debug('command returned failure (%d)', e.returncode)
+                logger.error('command output:\n%s', e.output)
+            logger.error('command returned failure (%d)', e.returncode)
             raise
 
     def installpkg(self, *pkgs):


### PR DESCRIPTION
Right now we dump all subprocess output to `program.log`.  Unfortunately,
The pungi/koji stack doesn't know how to scrape out the lorax logs.

And even when running interactively, it's annoying that *some* fatal
errors show up on stderr, but if it's from a subprocess, I need to go
over and `tail program.log`.

Let's output the subprocess stderr directly, since the user is
going to want it prominently anyways.