### PR TITLE
fix PYTHONDIR determenation in case of having both python2 and python3 pkgs in env

### DIFF
--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -3,7 +3,10 @@
 
 <%page args="root, basearch, libdir, configdir"/>
 <%
-PYTHONDIR = sorted(glob("usr/"+libdir+"/python?.?"))[0]
+## if we have both python-2 and python-3 pkgs in environment
+import os
+PYANACONDADIR = glob("usr/"+libdir+"/python?.?/site-packages/pyanaconda")[0]
+PYTHONDIR = os.path.dirname(os.path.dirname(PYANACONDADIR))
 stubs = ("list-harddrives", "raidstart", "raidstop")
 configdir = configdir + "/common"
 %>


### PR DESCRIPTION
In case of there is several python pkgs inside, like (python2 and python3) - current variant will fail / determine wrong. It's *more reliable* to determine dir something like this..