### PR TITLE
imgutils: Don't relabel /ostree

### DIFF
--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -114,7 +114,8 @@ def mkrootfsimg(rootdir, outfile, label, size=2, sysroot=""):
     # Reset selinux context on new rootfs
     with LoopDev(outfile) as loopdev:
         with Mount(loopdev) as mnt:
-            cmd = [ "setfiles", "-e", "/proc", "-e", "/sys", "-e", "/dev", "-e", "/install",
+            cmd = [ "setfiles", "-e", "/proc", "-e", "/sys", "-e", "/dev",
+                    "-e", "/install", "-e", "/ostree",
                     "/etc/selinux/targeted/contexts/files/file_contexts", "/"]
             root = join(mnt, sysroot.lstrip("/"))
             runcmd(cmd, root=root)


### PR DESCRIPTION
OSTree is a deduplicating hardlink store using a new file path
`/ostree`, which SELinux policy doesn't know about.  However, OSTree
has SELinux support built in, and rpm-ostree (for example) uses this
to ensure the attributes on files stored there are simply always
correct.  Relabeling it will corrupt it.

Hence, let's skip it.