### PR TITLE
Do not install rsh to anaconda chroot

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -160,7 +160,7 @@ installpkg fpaste
 
 ## extra tools not required by anaconda
 installpkg vim-minimal strace lsof dump xz less eject
-installpkg wget rsync rsh bind-utils ftp mtr vconfig
+installpkg wget rsync bind-utils ftp mtr vconfig
 installpkg icfg spice-vdagent
 installpkg gdisk hexedit sg3_utils
 


### PR DESCRIPTION
* `rsh` not used in anaconda now (can't find any mentions)
* `rsh` duplicates already existing ssh
* `rsh` not secure enough these days