### PR TITLE
Only cleanup libhistory from readline

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -292,7 +292,7 @@ removefrom procps /usr/bin/vmstat /usr/bin/w /usr/bin/watch
 removefrom psmisc /usr/share/locale/*
 removefrom pygtk2 /usr/bin/* /usr/${libdir}/pygtk/*
 removefrom pykickstart /usr/bin/* /usr/share/locale/*
-removefrom readline /usr/${libdir}/*
+removefrom readline /usr/${libdir}/libhistory*
 removefrom libreport /usr/bin/* /usr/share/locale/*
 removefrom rpm /usr/bin/* /usr/share/locale/*
 removefrom rsync /etc/*


### PR DESCRIPTION
with readline 7 libreadline.so moved to libdir as a result it is
currently removed in the cleanup phase, however it is needed

Signed-off-by: Dennis Gilmore <dennis@ausil.us>