### PR TITLE
Add dependency for lvmdump -l command (#1255659)

### DIFF
--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -59,7 +59,7 @@ removepkg avahi-autoipd coreutils-libs dash db4-utils diffutils file
 removepkg genisoimage gnome-python2 info iptables
 removepkg jasper-libs libXxf86misc
 removepkg libasyncns libhbaapi libhbalinux
-removepkg libmcpp libpcap libtiff libutempter linux-atm-libs
+removepkg libmcpp libtiff libutempter linux-atm-libs
 removepkg lvm2-libs m4 mailx makebootfat mcpp
 removepkg mingetty mobile-broadband-provider-info pkgconfig ppp pth
 removepkg rmt rpcbind squashfs-tools system-config-firewall-base

--- a/share/runtime-install.tmpl
+++ b/share/runtime-install.tmpl
@@ -79,7 +79,7 @@ installpkg gnome-keyring
 installpkg python-imaging
 
 ## filesystem tools
-installpkg btrfs-progs xfsprogs gfs2-utils 
+installpkg btrfs-progs xfsprogs gfs2-utils
 installpkg python-volume_key volume_key
 installpkg system-storage-manager
 installpkg device-mapper-persistent-data
@@ -96,6 +96,7 @@ installpkg tigervnc-server-module
 %endif
 installpkg net-tools
 installpkg bridge-utils
+installpkg nmap-ncat
 
 ## ntp packages
 installpkg ntp


### PR DESCRIPTION
This is required for pre installation log feature in Anaconda.

Required for https://github.com/rhinstaller/anaconda/pull/947 .

*Related: rhbz#1255659*