### PR TITLE
Add dependency for lvmdump -l command (#1255659)

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -63,7 +63,7 @@ removepkg avahi-autoipd coreutils-libs dash db4-utils diffutils file
 removepkg genisoimage info iptables
 removepkg jasper-libs libXxf86misc
 removepkg libasyncns libhbaapi libhbalinux
-removepkg libmcpp libpcap libtiff linux-atm-libs
+removepkg libmcpp libtiff linux-atm-libs
 removepkg lvm2-libs m4 mailx makebootfat mcpp
 removepkg mingetty mobile-broadband-provider-info pkgconfig ppp pth
 removepkg rmt rpcbind squashfs-tools system-config-firewall-base

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -113,6 +113,7 @@ installpkg tigervnc-server-module
 %endif
 installpkg net-tools
 installpkg bridge-utils
+installpkg nmap-ncat
 
 ## hardware utilities/libraries
 installpkg pciutils usbutils ipmitool


### PR DESCRIPTION
This is required for pre installation logging feature in Anaconda.

The `libpcap` library is dependency for `nmap-ncat` which is dependency for `lvmdump -l`.

Backport of PR: https://github.com/rhinstaller/lorax/pull/181