### PR TITLE
Fix duplicate kernel messages in /tmp/syslog (#1382611)

### DIFF
--- a/share/templates.d/99-generic/config_files/common/rsyslog.conf
+++ b/share/templates.d/99-generic/config_files/common/rsyslog.conf
@@ -9,7 +9,7 @@
 $ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
 $SystemLogRateLimitInterval 0 # disables message dropping, we need all of them
 $ModLoad imjournal # provides access to the systemd journal
-$ModLoad imklog # reads kernel messages (the same are read from journald)
+#$ModLoad imklog # reads kernel messages (the same are read from journald)
 #$ModLoad immark  # provides --MARK-- message capability
 
 # Provides UDP syslog reception


### PR DESCRIPTION
Resolves: rhbz#1382611

The kernel messages will be read from journal so don't use additional imlkog
module to read them duplicitly.

Fixup of
commit 3eca8a042541b874981bc2f3ee6f95d6aba122b7