### PR TITLE
Mount /dev to ensure /dev/urandom is available when executing rpm/nss

### DIFF
--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -116,9 +116,6 @@ remove etc/lvm/cache
 remove etc/lvm/lvm.conf
 append etc/lvm/lvm.conf "global {\n\tuse_lvmetad = 1\n}\n"
 
-# Ensure /dev/urandom is available
-runcmd chroot ${root} mount -t devtmpfs devtmpfs /dev
-
 ## Record the package versions used to create the image
 runcmd chroot ${root} /bin/rpm -qa --pipe "tee /root/lorax-packages.log"
 

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -116,6 +116,9 @@ remove etc/lvm/cache
 remove etc/lvm/lvm.conf
 append etc/lvm/lvm.conf "global {\n\tuse_lvmetad = 1\n}\n"
 
+# Ensure /dev/urandom is available
+runcmd chroot ${root} mount -t devtmpfs devtmpfs /dev
+
 ## Record the package versions used to create the image
 runcmd chroot ${root} /bin/rpm -qa --pipe "tee /root/lorax-packages.log"
 

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -116,6 +116,10 @@ remove etc/lvm/cache
 remove etc/lvm/lvm.conf
 append etc/lvm/lvm.conf "global {\n\tuse_lvmetad = 1\n}\n"
 
+# RPM with NSS requires /dev/urandom to be available
+mknod -m 444 /dev/random c 1 8
+mknod -m 444 /dev/urandom c 1 9
+
 ## Record the package versions used to create the image
 runcmd chroot ${root} /bin/rpm -qa --pipe "tee /root/lorax-packages.log"
 


### PR DESCRIPTION
NSS 3.29.x requires that /dev/urandom is available, which is the expected source of random data on Linux.
lorax uses rpm, rpm uses nss.
Without /dev/urandom, rpm fails.
See https://bugzilla.redhat.com/show_bug.cgi?id=1420523
