### PR TITLE
add ostree to get installed in anaconda environment

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -9,7 +9,7 @@ installpkg tmux
 installpkg gdb
 ## Other available payloads
 installpkg dnf
-installpkg rpm-ostree
+installpkg rpm-ostree ostree
 ## speed up compression on multicore systems
 installpkg pigz
 


### PR DESCRIPTION
rpm-ostree used to have a requirement on the ostree rpm. It no
longer has that dependency, but rather requires ostree-libs. However,
we call ostree directly in some cases so we need to have it installed.