### PR TITLE
Add --noverifyssl to lorax (#1430483)

### DIFF
--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -148,6 +148,8 @@ def main(args):
     optional.add_option("--add-arch-template-var", dest="add_arch_template_vars",
             action="append", help="Set variable for architecture-specific image",
             default=[])
+    optional.add_option("--noverifyssl", action="store_true", default=False,
+                        help="Do not verify SSL certificates")
 
     # add the option groups to the parser
     parser.add_option_group(required)
@@ -196,7 +198,7 @@ def main(args):
     os.mkdir(yumtempdir)
 
     yb = get_yum_base_object(installtree, opts.source, opts.mirrorlist,
-                             yumtempdir, opts.proxy, opts.excludepkgs)
+                             yumtempdir, opts.proxy, opts.excludepkgs, not opts.noverifyssl)
 
     if yb is None:
         print("error: unable to create the yumbase object", file=sys.stderr)
@@ -233,7 +235,7 @@ def main(args):
 
 
 def get_yum_base_object(installroot, repositories, mirrorlists=[],
-                        tempdir="/var/tmp", proxy=None, excludepkgs=[]):
+                        tempdir="/var/tmp", proxy=None, excludepkgs=[], sslverify=True):
 
     def sanitize_repo(repo):
         """Convert bare paths to file:/// URIs, and silently reject protocols unhandled by yum"""
@@ -270,6 +272,9 @@ def get_yum_base_object(installroot, repositories, mirrorlists=[],
 
     if proxy:
         data["proxy"] = proxy
+
+    if sslverify == False:
+        data["sslverify"] = "0"
 
     if excludepkgs:
         data["exclude"] = " ".join(excludepkgs)


### PR DESCRIPTION
Previously lorax had no way to use repos with self-signed certificates.
This adds the --noverifyssl cmdline option which will ignore certificate
errors.

Resolves: rhbz#1430483