### PR TITLE
Add --noverifyssl to lorax (#1430483)

### DIFF
--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -110,6 +110,8 @@ def lorax_parser():
                           metavar="[repo]", help="Names of repos to disable")
     optional.add_argument("--rootfs-size", type=int, default=2,
                           help="Size of root filesystem in GiB. Defaults to 2.")
+    optional.add_argument("--noverifyssl", action="store_true", default=False,
+                          help="Do not verify SSL certificates")
 
     # add the show version option
     parser.add_argument("-V", help="show program's version number and exit",

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -89,7 +89,7 @@ def main():
     dnfbase = get_dnf_base_object(installtree, opts.source, opts.mirrorlist, opts.repos,
                                   opts.enablerepos, opts.disablerepos,
                                   dnftempdir, opts.proxy, opts.version, opts.cachedir,
-                                  os.path.dirname(opts.logfile))
+                                  os.path.dirname(opts.logfile), not opts.noverifyssl)
 
     if dnfbase is None:
         print("error: unable to create the dnf base object", file=sys.stderr)
@@ -136,7 +136,7 @@ def main():
 def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,
                         enablerepos=None, disablerepos=None,
                         tempdir="/var/tmp", proxy=None, releasever="21",
-                        cachedir=None, logdir=None):
+                        cachedir=None, logdir=None, sslverify=True):
     """ Create a dnf Base object and setup the repositories and installroot
 
         :param string installroot: Full path to the installroot
@@ -148,6 +148,7 @@ def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,
         :param string proxy: http proxy to use when fetching packages
         :param string releasever: Release version to pass to dnf
         :param string cachedir: Directory to use for caching packages
+        :param bool noverifyssl: Set to True to ignore the CA of ssl certs. eg. use self-signed ssl for https repos.
 
         If tempdir is not set /var/tmp is used.
         If cachedir is None a dnf.cache directory is created inside tmpdir
@@ -194,6 +195,9 @@ def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,
 
     if proxy:
         conf.proxy = proxy
+
+    if sslverify == False:
+        conf.sslverify = False
 
     # Add .repo files
     if repos:


### PR DESCRIPTION
Previously lorax had no way to use repos with self-signed certificates.
This adds the --noverifyssl cmdline option which will ignore certificate
errors.

Resolves: rhbz#1430483