### PR TITLE
INSTALL_ROOT and LIVE_ROOT are not available during %post

### DIFF
--- a/docs/fedora-livemedia.ks
+++ b/docs/fedora-livemedia.ks
@@ -292,16 +292,6 @@ rm /var/lib/systemd/random-seed
 rm -f /boot/*-rescue*
 %end
 
-%post --nochroot
-cp $INSTALL_ROOT/usr/share/licenses/*-release/* $LIVE_ROOT/
-
-# only works on x86, x86_64
-if [ "$(uname -i)" = "i386" -o "$(uname -i)" = "x86_64" ]; then
-  if [ ! -d $LIVE_ROOT/LiveOS ]; then mkdir -p $LIVE_ROOT/LiveOS ; fi
-  cp /usr/bin/livecd-iso-to-disk $LIVE_ROOT/LiveOS
-fi
-%end
-
 %post
 
 cat >> /etc/rc.d/init.d/livesys << EOF

--- a/share/templates.d/99-generic/aarch64.tmpl
+++ b/share/templates.d/99-generic/aarch64.tmpl
@@ -52,12 +52,12 @@ mkdir ${KERNELDIR}
 %endif
 
 # Create optional product.img and updates.img
-<% imggraft=""; images=["product", "updates"] %>
+<% filegraft=""; images=["product", "updates"] %>
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${LORAXDIR}/${img}/ images/${img}.img
         treeinfo images-${basearch} ${img}.img images/${img}.img
-        <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
+        <% filegraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor
 
@@ -65,8 +65,14 @@ mkdir ${KERNELDIR}
 <%
     import os
     if os.path.exists(workdir + "/iso-graft"):
-        imggraft += " " + workdir + "/iso-graft"
+        filegraft += " " + workdir + "/iso-graft"
 %>
+
+# Add the license files
+%for f in glob("/usr/share/licenses/*-release/*"):
+    install ${f} ${f|basename}
+    <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
+%endfor
 
 %if exists("boot/efi/EFI/*/gcdaa64.efi"):
 ## make boot.iso
@@ -75,6 +81,6 @@ runcmd mkisofs -o ${outroot}/images/boot.iso \
        -graft-points \
        ${KERNELDIR}=${outroot}/${KERNELDIR} \
        ${STAGE2IMG}=${outroot}/${STAGE2IMG} \
-       ${efigraft} ${imggraft}
+       ${efigraft} ${filegraft}
 treeinfo images-${basearch} boot.iso images/boot.iso
 %endif

--- a/share/templates.d/99-generic/arm.tmpl
+++ b/share/templates.d/99-generic/arm.tmpl
@@ -52,7 +52,13 @@ treeinfo ${basearch} platforms ${platforms}
 <%
     import os
     if os.path.exists(workdir + "/iso-graft"):
-        imggraft += " " + workdir + "/iso-graft"
+        filegraft += " " + workdir + "/iso-graft"
 %>
+
+# Add the license files
+%for f in glob("/usr/share/licenses/*-release/*"):
+    install ${f} ${f|basename}
+    <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
+%endfor
 
 ## FIXME: ARM may need some extra boot config

--- a/share/templates.d/99-generic/live/arm.tmpl
+++ b/share/templates.d/99-generic/live/arm.tmpl
@@ -6,6 +6,8 @@ BOOTDIR="boot"
 KERNELDIR=PXEBOOTDIR
 LIVEDIR="LiveOS"
 LORAXDIR="usr/share/lorax/"
+
+from os.path import basename
 %>
 
 mkdir ${LIVEDIR}
@@ -39,6 +41,11 @@ mkdir ${KERNELDIR}
         installimg --xz -9 --memlimit-compress=3700MiB ${LORAXDIR}/${img}/ images/${img}.img
         treeinfo images-${basearch} ${img}.img images/${img}.img
     %endif
+%endfor
+
+# Add the license files
+%for f in glob("/usr/share/licenses/*-release/*"):
+    install ${f} ${f|basename}
 %endfor
 
 ## FIXME: ARM may need some extra boot config

--- a/share/templates.d/99-generic/live/ppc.tmpl
+++ b/share/templates.d/99-generic/live/ppc.tmpl
@@ -18,6 +18,8 @@ prepboot = ""
 ## Instead we'll just replace any non-ASCII characters in the isolabel
 ## with '_', which means we won't need any udev escapes.
 isolabel = ''.join(ch if ch.isalnum() else '_' for ch in isolabel)
+
+from os.path import basename
 %>
 
 ## Test ${runtime_img} to see if udf is needed
@@ -90,13 +92,19 @@ install ${configdir}/mapping ${BOOTDIR}
 %endfor
 
 # Create optional product.img and updates.img
-<% imggraft=""; images=["product", "updates"] %>
+<% filegraft=""; images=["product", "updates"] %>
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${LORAXDIR}/${img}/ images/${img}.img
         treeinfo images-${basearch} ${img}.img images/${img}.img
-        <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
+        <% filegraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
+%endfor
+
+# Add the license files
+%for f in glob("/usr/share/licenses/*-release/*"):
+    install ${f} ${f|basename}
+    <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor
 
 ## make boot.iso
@@ -111,7 +119,7 @@ runcmd mkisofs -o ${outroot}/images/boot.iso -chrp-boot -U \
         ${BOOTDIR}=${outroot}/${BOOTDIR} \
         ${GRUBDIR}=${outroot}/${GRUBDIR} \
         ${NETBOOTDIR}=${outroot}/${NETBOOTDIR} \
-        ${LIVEDIR}=${outroot}/${LIVEDIR} ${imggraft}
+        ${LIVEDIR}=${outroot}/${LIVEDIR} ${filegraft}
 
 %for kernel in kernels:
     treeinfo images-${kernel.arch} boot.iso images/boot.iso

--- a/share/templates.d/99-generic/live/s390.tmpl
+++ b/share/templates.d/99-generic/live/s390.tmpl
@@ -7,6 +7,8 @@ INITRD_ADDRESS="0x02000000"
 LORAXDIR="usr/share/lorax/"
 # The assumption seems to be that there is only one s390 kernel, ever
 kernel = kernels[0]
+
+from os.path import basename
 %>
 
 mkdir images
@@ -34,11 +36,17 @@ treeinfo images-${basearch} generic.prm ${BOOTDIR}/generic.prm
 treeinfo images-${basearch} generic.ins generic.ins
 
 # Create optional product.img and updates.img
-<% imggraft=""; images=["product", "updates"] %>
+<% filegraft=""; images=["product", "updates"] %>
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${LORAXDIR}/${img}/ images/${img}.img
         treeinfo images-${basearch} ${img}.img images/${img}.img
-        <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
+        <% filegraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
+%endfor
+
+# Add the license files
+%for f in glob("/usr/share/licenses/*-release/*"):
+    install ${f} ${f|basename}
+    <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor

--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -91,7 +91,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %endif
 
 # Create optional product.img and updates.img
-<% imggraft=""; images=["product", "updates"]; compressargs=None; %>
+<% filegraft=""; images=["product", "updates"]; compressargs=None; %>
 %if basearch == 'i386':
     # Limit the amount of memory xz uses on i386
     <% compressargs="--xz -9 --memlimit-compress=3700MiB" %>
@@ -100,8 +100,14 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${compressargs} ${LORAXDIR}/${img}/ images/${img}.img
         treeinfo images-${basearch} ${img}.img images/${img}.img
-        <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
+        <% filegraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
+%endfor
+
+# Add the license files
+%for f in glob("/usr/share/licenses/*-release/*"):
+    install ${f} ${f|basename}
+    <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor
 
 ## make boot.iso
@@ -113,6 +119,6 @@ runcmd mkisofs -o ${outroot}/images/boot.iso \
        ${BOOTDIR}=${outroot}/${BOOTDIR} \
        ${KERNELDIR}=${outroot}/${KERNELDIR} \
        ${LIVEDIR}=${outroot}/${LIVEDIR} \
-       ${efigraft} ${imggraft}
+       ${efigraft} ${filegraft}
 runcmd isohybrid ${efihybrid} ${outroot}/images/boot.iso
 treeinfo images-${basearch} boot.iso images/boot.iso

--- a/share/templates.d/99-generic/ppc.tmpl
+++ b/share/templates.d/99-generic/ppc.tmpl
@@ -21,6 +21,8 @@ isolabel = ''.join(ch if ch.isalnum() else '_' for ch in isolabel)
 
 ## Anaconda finds the CDROM device automatically
 rootarg = ""
+
+from os.path import basename
 %>
 
 ## Test ${runtime_img} to see if udf is needed
@@ -93,12 +95,12 @@ install ${configdir}/mapping ${BOOTDIR}
 %endfor
 
 # Create optional product.img and updates.img
-<% imggraft=""; images=["product", "updates"] %>
+<% filegraft=""; images=["product", "updates"] %>
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${LORAXDIR}/${img}/ images/${img}.img
         treeinfo images-${basearch} ${img}.img images/${img}.img
-        <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
+        <% filegraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor
 
@@ -106,8 +108,14 @@ install ${configdir}/mapping ${BOOTDIR}
 <%
     import os
     if os.path.exists(workdir + "/iso-graft"):
-        imggraft += " " + workdir + "/iso-graft"
+        filegraft += " " + workdir + "/iso-graft"
 %>
+
+# Add the license files
+%for f in glob("/usr/share/licenses/*-release/*"):
+    install ${f} ${f|basename}
+    <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
+%endfor
 
 ## make boot.iso
 runcmd mkisofs -o ${outroot}/images/boot.iso -chrp-boot -U \
@@ -120,7 +128,7 @@ runcmd mkisofs -o ${outroot}/images/boot.iso -chrp-boot -U \
         ${BOOTDIR}=${outroot}/${BOOTDIR} \
         ${GRUBDIR}=${outroot}/${GRUBDIR} \
         ${NETBOOTDIR}=${outroot}/${NETBOOTDIR} \
-        ${STAGE2IMG}=${outroot}/${STAGE2IMG} ${imggraft}
+        ${STAGE2IMG}=${outroot}/${STAGE2IMG} ${filegraft}
 
 
 %for kernel in kernels:

--- a/share/templates.d/99-generic/ppc64le.tmpl
+++ b/share/templates.d/99-generic/ppc64le.tmpl
@@ -14,6 +14,8 @@ isolabel = ''.join(ch if ch.isalnum() else '_' for ch in isolabel)
 
 ## Anaconda finds the CDROM device automatically
 rootarg = ""
+
+from os.path import basename
 %>
 
 ## Test ${runtime_img} to see if udf is needed
@@ -69,12 +71,12 @@ install ${configdir}/mapping ${BOOTDIR}
 
 mkdir images/
 # Create optional product.img and updates.img
-<% imggraft=""; images=["product", "updates"] %>
+<% filegraft=""; images=["product", "updates"] %>
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${LORAXDIR}/${img}/ images/${img}.img
         treeinfo images-${basearch} ${img}.img images/${img}.img
-        <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
+        <% filegraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor
 
@@ -82,8 +84,14 @@ mkdir images/
 <%
     import os
     if os.path.exists(workdir + "/iso-graft"):
-        imggraft += " " + workdir + "/iso-graft"
+        filegraft += " " + workdir + "/iso-graft"
 %>
+
+# Add the license files
+%for f in glob("/usr/share/licenses/*-release/*"):
+    install ${f} ${f|basename}
+    <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
+%endfor
 
 ## make boot.iso
 runcmd mkisofs -v -U -J -R -T \
@@ -96,7 +104,7 @@ runcmd mkisofs -v -U -J -R -T \
         -no-desktop -allow-multidot ${udfargs} -graft-points \
         ${BOOTDIR}=${outroot}/${BOOTDIR} \
         ${GRUBDIR}=${outroot}/${GRUBDIR} \
-        ${STAGE2IMG}=${outroot}/${STAGE2IMG} ${imggraft}
+        ${STAGE2IMG}=${outroot}/${STAGE2IMG} ${filegraft}
 
 %for kernel in kernels:
     treeinfo images-${kernel.arch} boot.iso images/boot.iso

--- a/share/templates.d/99-generic/s390.tmpl
+++ b/share/templates.d/99-generic/s390.tmpl
@@ -7,6 +7,8 @@ INITRD_ADDRESS="0x02000000"
 LORAXDIR="usr/share/lorax/"
 # The assumption seems to be that there is only one s390 kernel, ever
 kernel = kernels[0]
+
+from os.path import basename
 %>
 
 mkdir images
@@ -36,12 +38,12 @@ treeinfo images-${basearch} genericdvd.prm ${BOOTDIR}/genericdvd.prm
 treeinfo images-${basearch} generic.ins generic.ins
 
 # Create optional product.img and updates.img
-<% imggraft=""; images=["product", "updates"] %>
+<% filegraft=""; images=["product", "updates"] %>
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${LORAXDIR}/${img}/ images/${img}.img
         treeinfo images-${basearch} ${img}.img images/${img}.img
-        <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
+        <% filegraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor
 
@@ -49,5 +51,11 @@ treeinfo images-${basearch} generic.ins generic.ins
 <%
     import os
     if os.path.exists(workdir + "/iso-graft"):
-        imggraft += " " + workdir + "/iso-graft"
+        filegraft += " " + workdir + "/iso-graft"
 %>
+
+# Add the license files
+%for f in glob("/usr/share/licenses/*-release/*"):
+    install ${f} ${f|basename}
+    <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
+%endfor

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -93,7 +93,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %endif
 
 # Create optional product.img and updates.img
-<% imggraft=""; images=["product", "updates"]; compressargs=None; %>
+<% filegraft=""; images=["product", "updates"]; compressargs=None; %>
 %if basearch == 'i386':
     # Limit the amount of memory xz uses on i386
     <% compressargs="--xz -9 --memlimit-compress=3700MiB" %>
@@ -102,7 +102,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg ${compressargs} ${LORAXDIR}/${img}/ images/${img}.img
         treeinfo images-${basearch} ${img}.img images/${img}.img
-        <% imggraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
+        <% filegraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor
 
@@ -110,8 +110,14 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 <%
     import os
     if os.path.exists(workdir + "/iso-graft"):
-        imggraft += " " + workdir + "/iso-graft"
+        filegraft += " " + workdir + "/iso-graft"
 %>
+
+# Add the license files
+%for f in glob("/usr/share/licenses/*-release/*"):
+    install ${f} ${f|basename}
+    <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
+%endfor
 
 ## make boot.iso
 runcmd mkisofs -o ${outroot}/images/boot.iso \
@@ -122,6 +128,6 @@ runcmd mkisofs -o ${outroot}/images/boot.iso \
        ${STAGE2IMG}=${outroot}/${STAGE2IMG} \
        ${BOOTDIR}=${outroot}/${BOOTDIR} \
        ${KERNELDIR}=${outroot}/${KERNELDIR} \
-       ${efigraft} ${imggraft}
+       ${efigraft} ${filegraft}
 runcmd isohybrid ${efihybrid} ${outroot}/images/boot.iso
 treeinfo images-${basearch} boot.iso images/boot.iso


### PR DESCRIPTION
These were set by livecd-creator. In order to install the license files to the / of the iso they need to be copied in the arch-specific templates and added to the mkisofs graft path.