### PR TITLE
Make 64-bit kernel on 32-bit firmware work for x86 efi machines

### DIFF
--- a/share/aarch64.tmpl
+++ b/share/aarch64.tmpl
@@ -35,7 +35,7 @@ mkdir ${KERNELDIR}
         efiargs += " -eltorito-alt-boot -e {0} -no-emul-boot".format(img)
         efigraft += " {0}={1}/{0}".format(img,outroot)
     %>
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel"/>
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch64=efiarch, isolabel=isolabel"/>
 
     # Create optional product.img and updates.img
     <% imggraft=""; images=["product", "updates"] %>

--- a/share/efi.tmpl
+++ b/share/efi.tmpl
@@ -1,4 +1,4 @@
-<%page args="configdir, KERNELDIR, efiarch, isolabel"/>
+<%page args="configdir, KERNELDIR, efiarch32, efiarch64, isolabel"/>
 <%
 from string import lower
 EFIBOOTDIR="EFI/BOOT"
@@ -8,13 +8,20 @@ APPLE_EFI_DISKNAME=inroot+"/usr/share/pixmaps/bootloader/fedora-media.vol"
 
 mkdir ${EFIBOOTDIR}
 mkdir ${EFIBOOTDIR}/fonts/
-install boot/efi/EFI/*/shim.efi ${EFIBOOTDIR}/BOOT${efiarch}.EFI
-install boot/efi/EFI/*/MokManager.efi ${EFIBOOTDIR}/
-install boot/efi/EFI/*/gcd${efiarch|lower}.efi ${EFIBOOTDIR}/grub${efiarch|lower}.efi
-install boot/efi/EFI/*/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
 %if exists("usr/share/shim/lockdown.efi"):
-    install usr/share/shim/lockdown.efi ${EFIBOOTDIR}/
+	install usr/share/shim/lockdown.efi ${EFIBOOTDIR}/
 %endif
+%if efiarch64:
+install boot/efi/EFI/*/shim${efiarch64|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch64}.EFI
+install boot/efi/EFI/*/mm${efiarch64|lower}.efi ${EFIBOOTDIR}/
+install boot/efi/EFI/*/gcd${efiarch64|lower}.efi ${EFIBOOTDIR}/grub${efiarch64|lower}.efi
+%endif
+%if efiarch32:
+install boot/efi/EFI/*/shim${efiarch32|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch32}.EFI
+install boot/efi/EFI/*/mm${efiarch32|lower}.efi ${EFIBOOTDIR}/
+install boot/efi/EFI/*/gcd${efiarch32|lower}.efi ${EFIBOOTDIR}/grub${efiarch32|lower}.efi
+%endif
+install boot/efi/EFI/*/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
 
 ## actually make the EFI images
 ${make_efiboot("images/efiboot.img")}
@@ -50,9 +57,6 @@ ${make_efiboot("images/efiboot.img")}
         replace @ROOT@ inst.stage2=hd:LABEL=ANACONDA ${eficonf}
     %else:
         replace @ROOT@ 'inst.stage2=hd:LABEL=${isolabel|udev}' ${eficonf}
-    %endif
-    %if efiarch == 'IA32':
-        copy ${eficonf} ${EFIBOOTDIR}/BOOT.conf
     %endif
     runcmd mkefiboot ${args} ${outroot}/${EFIBOOTDIR} ${outroot}/${img}
     %if include_kernel:

--- a/share/live/efi.tmpl
+++ b/share/live/efi.tmpl
@@ -1,4 +1,4 @@
-<%page args="configdir, KERNELDIR, efiarch, isolabel"/>
+<%page args="configdir, KERNELDIR, efiarch32, efiarch64, isolabel"/>
 <%
 from string import lower
 EFIBOOTDIR="EFI/BOOT"
@@ -8,13 +8,20 @@ APPLE_EFI_DISKNAME=inroot+"/usr/share/pixmaps/bootloader/fedora-media.vol"
 
 mkdir ${EFIBOOTDIR}
 mkdir ${EFIBOOTDIR}/fonts/
-install boot/efi/EFI/*/shim.efi ${EFIBOOTDIR}/BOOT${efiarch}.EFI
-install boot/efi/EFI/*/MokManager.efi ${EFIBOOTDIR}/
-install boot/efi/EFI/*/gcd${efiarch|lower}.efi ${EFIBOOTDIR}/grub${efiarch|lower}.efi
-install boot/efi/EFI/*/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
 %if exists("usr/share/shim/lockdown.efi"):
-    install usr/share/shim/lockdown.efi ${EFIBOOTDIR}/
+	install usr/share/shim/lockdown.efi ${EFIBOOTDIR}/
 %endif
+%if efiarch64
+install boot/efi/EFI/*/shim${efiarch64|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch64}.EFI
+install boot/efi/EFI/*/mm${efiarch64|lower}.efi ${EFIBOOTDIR}/
+install boot/efi/EFI/*/gcd${efiarch64|lower}.efi ${EFIBOOTDIR}/grub${efiarch64|lower}.efi
+%endif
+%if efiarch32:
+install boot/efi/EFI/*/shim${efiarch32|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch32}.EFI
+install boot/efi/EFI/*/mm${efiarch32|lower}.efi ${EFIBOOTDIR}/
+install boot/efi/EFI/*/gcd${efiarch32|lower}.efi ${EFIBOOTDIR}/grub${efiarch32|lower}.efi
+%endif
+install boot/efi/EFI/*/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
 
 ## actually make the EFI images
 ${make_efiboot("images/efiboot.img")}
@@ -50,9 +57,6 @@ ${make_efiboot("images/efiboot.img")}
         replace @ROOT@ root=live:LABEL=ANACONDA ${eficonf}
     %else:
         replace @ROOT@ 'root=live:CDLABEL=${isolabel|udev}' ${eficonf}
-    %endif
-    %if efiarch == 'IA32':
-        copy ${eficonf} ${EFIBOOTDIR}/BOOT.conf
     %endif
     runcmd mkefiboot ${args} ${outroot}/${EFIBOOTDIR} ${outroot}/${img}
     %if include_kernel:

--- a/share/live/x86.tmpl
+++ b/share/live/x86.tmpl
@@ -48,11 +48,15 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %endif
 
 ## WHeeeeeeee, EFI.
-## We could remove the basearch restriction someday..
-<% efiargs=""; efigraft=""; efihybrid="" %>
-%if exists("boot/efi/EFI/*/gcdx64.efi") and basearch != 'i386':
+<% efiargs=""; efigraft=""; efihybrid=""; efiarch32=None; efiarch64=None %>
+%if exists("boot/efi/EFI/*/gcdia32.efi"):
+    <% efiarch32 = 'IA32' %>
+%endif
+%if exists("boot/efi/EFI/*/gcdx64.efi"):
+    <% efiarch64 = 'X64' %>
+%endif
+%if efiarch32 or efiarch64:
     <%
-    efiarch = 'X64' if basearch=='x86_64' else 'IA32'
     efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
     images = ["images/efiboot.img"]
     if domacboot:
@@ -62,7 +66,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
         efigraft += " {0}={1}/{0}".format(img,outroot)
     efihybrid = "--uefi --mac" if domacboot else "--uefi"
     %>
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel"/>
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=efiarch32, efiarch64=efiarch64, isolabel=isolabel"/>
 %endif
 
 # Create optional product.img and updates.img

--- a/share/runtime-install.tmpl
+++ b/share/runtime-install.tmpl
@@ -20,7 +20,7 @@ installpkg kernel
 
 ## arch-specific packages (bootloaders etc.)
 %if basearch == "aarch64":
-    installpkg efibootmgr grub2-efi grub2-efi-modules grubby shim shim-unsigned
+    installpkg efibootmgr grub2-efi-aa64-cdboot grubby shim-aa64
 %endif
 %if basearch in ("arm", "armhfp"):
     installpkg kernel-lpae kernel-tegra
@@ -29,13 +29,22 @@ installpkg kernel
 %if basearch == "i386":
     installpkg kernel-PAE gpart
 %endif
+%if basearch == "x86_64":
+    installpkg grub2-tools-efi
+    installpkg shim-x64 grub2-efi-x64-cdboot
+%endif
 %if basearch in ("i386", "x86_64"):
-    installpkg grub2 grub2-tools biosdevname memtest86+ syslinux
-    installpkg efibootmgr grub2-efi grub2-efi-modules shim shim-unsigned
+    installpkg biosdevname memtest86+ syslinux
+    # installpkg grub2-tools grub2-tools-minimal
+    installpkg efibootmgr
+    installpkg shim-ia32 grub2-efi-ia32-cdboot
 %endif
 %if basearch in ("ppc", "ppc64", "ppc64le"):
-    installpkg grub2 grub2-tools fbset hfsutils kernel-bootwrapper ppc64-utils
+    installpkg fbset hfsutils kernel-bootwrapper ppc64-utils
+    installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
+    installpkg grub2-${basearch}
 %endif
+
 %if basearch == "s390x":
     installpkg lsscsi s390utils-base s390utils-cmsfs-fuse
 %endif

--- a/share/x86.tmpl
+++ b/share/x86.tmpl
@@ -62,11 +62,15 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %endif
 
 ## WHeeeeeeee, EFI.
-## We could remove the basearch restriction someday..
-<% efiargs=""; efigraft=""; efihybrid="" %>
-%if exists("boot/efi/EFI/*/gcdx64.efi") and basearch != 'i386':
+<% efiargs=""; efigraft=""; efihybrid=""; efiarch32=None; efiarch64=None %>
+%if exists("boot/efi/EFI/*/gcdia32.efi"):
+    <% efiarch32 = 'IA32' %>
+%endif
+%if exists("boot/efi/EFI/*/gcdx64.efi"):
+    <% efiarch64 = 'X64' %>
+%endif
+%if efiarch32 or efiarch64:
     <%
-    efiarch = 'X64' if basearch=='x86_64' else 'IA32'
     efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
     images = ["images/efiboot.img"]
     if domacboot:
@@ -76,7 +80,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
         efigraft += " {0}={1}/{0}".format(img,outroot)
     efihybrid = "--uefi --mac" if domacboot else "--uefi"
     %>
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel"/>
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=efiarch32, efiarch64=efiarch64, isolabel=isolabel"/>
 %endif
 
 # Create optional product.img and updates.img


### PR DESCRIPTION
This enables Baytrail and similar atom CPUs that typically ship with a
32-bit firmware, but have a 64-bit capable CPU.

Resolves: rhbz#1310775

Signed-off-by: Peter Jones <pjones@redhat.com>