### PR TITLE
Add support for --repo to read yum .repo files directly (#1430479)

### DIFF
--- a/docs/lorax.1
+++ b/docs/lorax.1
@@ -3,7 +3,7 @@
 lorax \- Create installer boot iso
 
 .SH SYNOPSIS
-lorax -p PRODUCT -v VERSION -r RELEASE -s REPOSITORY OUTPUTDIR
+lorax -p PRODUCT -v VERSION -r RELEASE [-s REPOSITORY|--repo CONFIG] OUTPUTDIR
 
 .SH DESCRIPTION
 
@@ -36,6 +36,10 @@ release information
 .TP
 \fB\-s REPOSITORY, \-\-source=REPOSITORY\fR
 source repository (may be listed multiple times)
+
+.TP
+\fB\--repo CONFIG\fR
+repository configuration file (may be listed multiple times)
 
 .SH
 OPTIONAL ARGUMENTS:

--- a/docs/rhel7-livemedia.ks
+++ b/docs/rhel7-livemedia.ks
@@ -369,4 +369,5 @@ syslinux
 
 # This package is needed to boot the iso on UEFI
 grub2-efi-*-cdboot
+grub2-efi-ia32
 %end

--- a/docs/rhel7-minimal.ks
+++ b/docs/rhel7-minimal.ks
@@ -56,6 +56,7 @@ syslinux
 
 # Boot on 32bit UEFI
 shim-ia32
+grub2-efi-ia32
 
 # NOTE: To build a bootable UEFI disk image livemedia-creator needs to be
 #       run on a UEFI system or virt.

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -31,6 +31,7 @@ yum_log = logging.getLogger("yum")
 
 import sys
 import os
+import shutil
 import tempfile
 from optparse import OptionParser, OptionGroup
 import ConfigParser
@@ -99,6 +100,9 @@ def main(args):
     required.add_option("-s", "--source",
             help="source repository (may be listed multiple times)",
             metavar="REPOSITORY", action="append", default=[])
+    required.add_option("--repo",
+            help="source yum repository file",
+            dest="repo_files", metavar="REPOSITORY", action="append", default=[])
 
     # optional arguments
     optional = OptionGroup(parser, "optional arguments")
@@ -173,7 +177,7 @@ def main(args):
 
     # check for the required arguments
     if not opts.product or not opts.version or not opts.release \
-            or not opts.source or not outputdir:
+            or not (opts.source or opts.repo_files) or not outputdir:
         parser.error("missing one or more required arguments")
 
     if os.path.exists(outputdir):
@@ -198,6 +202,7 @@ def main(args):
     os.mkdir(yumtempdir)
 
     yb = get_yum_base_object(installtree, opts.source, opts.mirrorlist,
+                             opts.repo_files,
                              yumtempdir, opts.proxy, opts.excludepkgs,
                              not opts.noverifyssl)
 
@@ -235,7 +240,7 @@ def main(args):
               remove_temp=True)
 
 
-def get_yum_base_object(installroot, repositories, mirrorlists=[],
+def get_yum_base_object(installroot, repositories, mirrorlists=[], repo_files=[],
                         tempdir="/var/tmp", proxy=None, excludepkgs=[],
                         sslverify=True):
 
@@ -285,13 +290,15 @@ def get_yum_base_object(installroot, repositories, mirrorlists=[],
     map(lambda (key, value): c.set(section, key, value), data.items())
 
     # add the main repository - the first repository from list
-    section = "lorax-repo"
-    data = {"name": "lorax repo",
-            "baseurl": repositories[0],
-            "enabled": 1}
+    # This list may be empty if using --repo to load .repo files
+    if repositories:
+        section = "lorax-repo"
+        data = {"name": "lorax repo",
+                "baseurl": repositories[0],
+                "enabled": 1}
 
-    c.add_section(section)
-    map(lambda (key, value): c.set(section, key, value), data.items())
+        c.add_section(section)
+        map(lambda (key, value): c.set(section, key, value), data.items())
 
     # add the extra repositories
     for n, extra in enumerate(repositories[1:], start=1):
@@ -329,6 +336,11 @@ def get_yum_base_object(installroot, repositories, mirrorlists=[],
     yb.preconf.errorlevel = 6
     yb.logger.setLevel(logging.DEBUG)
     yb.verbose_logger.setLevel(logging.DEBUG)
+
+    # Add .repo files from the cmdline
+    for fn in repo_files:
+        if os.path.exists(fn):
+            yb.getReposFromConfigFile(fn)
 
     return yb
 


### PR DESCRIPTION
This makes it easier to specify existing repos with extra args, eg.
/etc/yum.repos.d/redhat.repo generated by subscription-manager.

Resolves: rhbz#1430479