### PR TITLE
Fix aarch64 efi.tmpl invocation

### DIFF
--- a/share/aarch64.tmpl
+++ b/share/aarch64.tmpl
@@ -35,7 +35,7 @@ mkdir ${KERNELDIR}
         efiargs += " -eltorito-alt-boot -e {0} -no-emul-boot".format(img)
         efigraft += " {0}={1}/{0}".format(img,outroot)
     %>
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch64=efiarch, isolabel=isolabel"/>
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=None, efiarch64=efiarch, isolabel=isolabel"/>
 
     # Create optional product.img and updates.img
     <% imggraft=""; images=["product", "updates"] %>


### PR DESCRIPTION
We didn't add "efiarch32" on aarch64 because it made no sense, but we
need to because it's not an optional argument in the other template.
Just make it efiarch32=None.

Related: rhbz#1310775

Signed-off-by: Peter Jones <pjones@redhat.com>