### PR TITLE
Use anaconda-core to detect buildarch

### DIFF
--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -373,12 +373,12 @@ def get_buildarch(dbo):
     buildarch = None
     q = dbo.sack.query()
     a = q.available()
-    for anaconda in a.filter(name="anaconda"):
+    for anaconda in a.filter(name="anaconda-core"):
         if anaconda.arch != "src":
             buildarch = anaconda.arch
             break
     if not buildarch:
-        logger.critical("no anaconda package in the repository")
+        logger.critical("no anaconda-core package in the repository")
         sys.exit(1)
 
     return buildarch


### PR DESCRIPTION
For historical reasons, lorax used the 'anaconda' package as a
touchstone to determine the architecture for the build. At some
point, this package became a metapackage that pulls in both the
GUI and headless installers.

In the modular world, it's possible that only the core and TUI bits
may be available for use. The only subpackage of anaconda that is
guaranteed to be on any viable system is anaconda-core, so let's
switch to using that for the touchstone instead of the metapackage.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>