### PR TITLE
Fix aarch64 efi.tmpl invocation for live images

### DIFF
--- a/share/live/aarch64.tmpl
+++ b/share/live/aarch64.tmpl
@@ -54,7 +54,7 @@ mkdir ${KERNELDIR}
         %>
         treeinfo images-${basearch} ${img|basename} ${img}
     %endfor
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel"/>
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=None, efiarch64=efiarch, isolabel=isolabel"/>
 %endif
 
 # Create optional product.img and updates.img

--- a/share/live/efi.tmpl
+++ b/share/live/efi.tmpl
@@ -11,7 +11,7 @@ mkdir ${EFIBOOTDIR}/fonts/
 %if exists("usr/share/shim/lockdown.efi"):
 	install usr/share/shim/lockdown.efi ${EFIBOOTDIR}/
 %endif
-%if efiarch64
+%if efiarch64:
 install boot/efi/EFI/*/shim${efiarch64|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch64}.EFI
 install boot/efi/EFI/*/mm${efiarch64|lower}.efi ${EFIBOOTDIR}/
 install boot/efi/EFI/*/gcd${efiarch64|lower}.efi ${EFIBOOTDIR}/grub${efiarch64|lower}.efi


### PR DESCRIPTION
We didn't add "efiarch32" on aarch64 because it made no sense, but we
need to because it's not an optional argument in the other template.
Just make it efiarch32=None.

Also fixes a typo in share/live/uefi.tmpl

Related: rhbz#1310775