### PR TITLE
Update livemedia-creator examples

### DIFF
--- a/README.livemedia-creator
+++ b/README.livemedia-creator
@@ -145,6 +145,16 @@ You can also add an update repo, but don't name it updates. Add --proxy to
 it as well.
 
 
+UEFI Disk Image Creation
+------------------------
+When making a live iso the bootloader is added after Anaconda has run. As long as
+anaconda-tools and grub2-efi-*-cdboot are included in the kickstart the iso will
+be bootable on UEFI systems.
+
+To create a disk image, eg. using rhel7-minimal.ks, livemedia-creator needs to be
+run from a UEFI system or virt running UEFI firmware.
+
+
 ANACONDA IMAGE INSTALL
 ----------------------
 You can create images without using virt-install by passing --no-virt on the

--- a/docs/rhel7-livemedia.ks
+++ b/docs/rhel7-livemedia.ks
@@ -351,7 +351,10 @@ cat /dev/null > /etc/fstab
 %end
 
 %packages
-@anaconda-tools
+# Packages needed by anaconda, but not directly required.
+# Includes all of the grub2 and shim packages needed, except
+# for the grub2-efi-*-cdboot package
+@anaconda-tools --optional
 @core
 @fonts
 @x11
@@ -363,4 +366,7 @@ kernel
 memtest86+
 syslinux
 -dracut-config-rescue
+
+# This package is needed to boot the iso on UEFI
+grub2-efi-*-cdboot
 %end

--- a/docs/rhel7-minimal.ks
+++ b/docs/rhel7-minimal.ks
@@ -47,9 +47,16 @@ rm /var/lib/systemd/random-seed
 @core
 kernel
 memtest86+
+efibootmgr
 grub2-efi
 grub2
 shim
 syslinux
 -dracut-config-rescue
+
+# Boot on 32bit UEFI
+shim-ia32
+
+# NOTE: To build a bootable UEFI disk image livemedia-creator needs to be
+#       run on a UEFI system or virt.
 %end


### PR DESCRIPTION
Make sure grub2-efi-*-cdboot is included in the live media kickstart,
add some documentation about creating UEFI disk images, and add ia32 to
the minimal example (it will need to be commented out for other arches).

Resolves: rhbz#1458937