### PR TITLE
Remove the iso-graft check from the aarch64.tmpl

### DIFF
--- a/share/live/aarch64.tmpl
+++ b/share/live/aarch64.tmpl
@@ -67,13 +67,6 @@ mkdir ${KERNELDIR}
     %endif
 %endfor
 
-# Inherit iso-graft/ if it exists from external templates
-<%
-    import os
-    if os.path.exists(workdir + "/iso-graft"):
-        filegraft += " " + workdir + "/iso-graft"
-%>
-
 # Add the license files
 %for f in glob("/usr/share/licenses/*-release/*"):
     install ${f} ${f|basename}


### PR DESCRIPTION
RHEL7 doesn't support the workdir+/iso-graft feature.

Resolves: rhbz#1369014