### PR TITLE
perl is needed on all arches now

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -5,11 +5,10 @@
 remove usr/share/i18n
 
 ## not required packages installed as dependencies
-## no perl besides s390x
+## perl is needed on s390x
 ## perl needed for powerpc-utils and fbset on PPC
-%if basearch not in ("ppc", "ppc64", "ppc64le", "s390x"):
-    removepkg perl*
-%endif
+## perl is needed by /usr/bin/rxe_cfg from libibverbs
+
 ## no sound support, thanks
 removepkg flac gstreamer-tools libsndfile pulseaudio* sound-theme-freedesktop
 ## we don't create new initramfs/bootloader conf inside anaconda


### PR DESCRIPTION
/usr/bin/rxe_cfg from libibverbs needs perl. so include it everywhere.

Signed-off-by: Dennis Gilmore <dennis@ausil.us>