### PR TITLE
runtime-cleanup: preserve a couple more gstreamer libs

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -346,7 +346,7 @@ runcmd chroot ${root} find -L /etc /usr -xdev -type l -and \! -name "mtab" \
 removefrom gstreamer1 --allbut /usr/${libdir}/libgstbase-1.0.* \
                                /usr/${libdir}/libgstreamer-1.0.*
 removefrom gstreamer1-plugins-base --allbut \
-        /usr/${libdir}/libgst{app,audio,fft,pbutils,tag,video}-1.0.*
+        /usr/${libdir}/libgst{allocators,app,audio,badallocators,fft,pbutils,tag,video}-1.0.*
 
 ## We have enough geoip libraries, thanks
 removepkg geoclue2


### PR DESCRIPTION
As of webkitgtk4-2.17.5-1.fc27 , it needs these two as well as
the others. This is breaking Rawhide composes at present.

Signed-off-by: Adam Williamson <awilliam@redhat.com>