### PR TITLE
Include the dracut fips module in the initrd (#1341280)

### DIFF
--- a/README.livemedia-creator
+++ b/README.livemedia-creator
@@ -87,6 +87,15 @@ iso using GNOME, and the other to create a minimal disk image. When creating you
 own kickstarts you should start with the minimal example, it includes several
 needed packages that are not always included by dependencies.
 
+livemedia-creator parses the 'part /' entry to determine how big a disk image
+needs to be created. This means that the common kickstart technique of using
+%pre to generate a partition scheme for use with %include will not work. There
+needs to be a 'part /' entry in the main part of the kickstart.
+
+Only one kickstart file is supported, so if your kickstart is built from a
+number of %include commands it needs to be flattened into a single file with
+ksflatten first.
+
 Or you can use existing spin kickstarts to create live media with a few
 changes. Here are the steps I used to convert the Fedora XFCE spin.
 

--- a/docs/lorax.1
+++ b/docs/lorax.1
@@ -3,7 +3,7 @@
 lorax \- Create installer boot iso
 
 .SH SYNOPSIS
-lorax -p PRODUCT -v VERSION -r RELEASE -s REPOSITORY OUTPUTDIR
+lorax -p PRODUCT -v VERSION -r RELEASE [-s REPOSITORY|--repo CONFIG] OUTPUTDIR
 
 .SH DESCRIPTION
 
@@ -36,6 +36,10 @@ release information
 .TP
 \fB\-s REPOSITORY, \-\-source=REPOSITORY\fR
 source repository (may be listed multiple times)
+
+.TP
+\fB\--repo CONFIG\fR
+repository configuration file (may be listed multiple times)
 
 .SH
 OPTIONAL ARGUMENTS:
@@ -88,6 +92,10 @@ Path to logfile
 .TP
 \fB\-\-tmp=TMP\fR
 Top level temporary directory
+
+.TP
+\fB\-\-noverifyssl\fR
+This disables SSL certificate checking. eg. to allow using https: sources with self-signed certificates.
 
 .SH AUTHORS
 .nf

--- a/docs/rhel7-livemedia.ks
+++ b/docs/rhel7-livemedia.ks
@@ -369,4 +369,5 @@ syslinux
 
 # This package is needed to boot the iso on UEFI
 grub2-efi-*-cdboot
+grub2-efi-ia32
 %end

--- a/docs/rhel7-minimal.ks
+++ b/docs/rhel7-minimal.ks
@@ -56,6 +56,7 @@ syslinux
 
 # Boot on 32bit UEFI
 shim-ia32
+grub2-efi-ia32
 
 # NOTE: To build a bootable UEFI disk image livemedia-creator needs to be
 #       run on a UEFI system or virt.

--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -67,7 +67,7 @@ removepkg tigervnc-license ttmkfdir xml-common xorg-x11-font-utils
 removepkg xorg-x11-server-common yum-utils
 
 ## other removals
-remove /boot /home /media /opt /srv /tmp/*
+remove /home /media /opt /srv /tmp/*
 remove /usr/etc /usr/games /usr/local /usr/tmp
 remove /usr/share/doc /usr/share/info /usr/share/man /usr/share/gnome
 remove /usr/share/mime/application /usr/share/mime/audio /usr/share/mime/image
@@ -346,6 +346,11 @@ removefrom subscription-manager --allbut /etc/rhsm/* /usr/share/rhsm/* /var/log/
 ## cleanup_python_files()
 runcmd find ${root} -name "*.pyo" -type f -delete
 runcmd find ${root} -name "*.pyc" -type f -exec ln -sf /dev/null {} \;
+
+## cleanup /boot/ leaving vmlinuz, and .*hmac files
+runcmd chroot ${root} find /boot \! -name "vmlinuz*" \
+                            -and \! -name ".vmlinuz*" \
+                            -and \! -name boot -delete
 
 ## remove any broken links in /etc or /usr
 ## (broken systemd service links lead to confusing noise at boot)

--- a/share/runtime-install.tmpl
+++ b/share/runtime-install.tmpl
@@ -53,7 +53,7 @@ installpkg kernel
 installpkg plymouth
 
 ## extra dracut modules
-installpkg anaconda-dracut dracut-network dracut-config-generic
+installpkg anaconda-dracut dracut-network dracut-config-generic dracut-fips
 
 ## redhat-upgrade-dracut handles upgrades on RHEL
 installpkg redhat-upgrade-dracut redhat-upgrade-dracut-plymouth

--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -311,7 +311,7 @@ class Lorax(BaseLoraxClass):
                                   workdir=self.workdir)
 
         logger.info("rebuilding initramfs images")
-        dracut_args = ["--xz", "--install", "/.buildstamp", "--no-early-microcode"]
+        dracut_args = ["--xz", "--install", "/.buildstamp", "--no-early-microcode", "--add", "fips"]
         anaconda_args = dracut_args + ["--add", "anaconda pollcdrom"]
 
         # ppc64 cannot boot an initrd > 32MiB so remove some drivers

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -31,6 +31,7 @@ yum_log = logging.getLogger("yum")
 
 import sys
 import os
+import shutil
 import tempfile
 from optparse import OptionParser, OptionGroup
 import ConfigParser
@@ -99,6 +100,9 @@ def main(args):
     required.add_option("-s", "--source",
             help="source repository (may be listed multiple times)",
             metavar="REPOSITORY", action="append", default=[])
+    required.add_option("--repo",
+            help="source yum repository file",
+            dest="repo_files", metavar="REPOSITORY", action="append", default=[])
 
     # optional arguments
     optional = OptionGroup(parser, "optional arguments")
@@ -173,7 +177,7 @@ def main(args):
 
     # check for the required arguments
     if not opts.product or not opts.version or not opts.release \
-            or not opts.source or not outputdir:
+            or not (opts.source or opts.repo_files) or not outputdir:
         parser.error("missing one or more required arguments")
 
     if os.path.exists(outputdir):
@@ -198,6 +202,7 @@ def main(args):
     os.mkdir(yumtempdir)
 
     yb = get_yum_base_object(installtree, opts.source, opts.mirrorlist,
+                             opts.repo_files,
                              yumtempdir, opts.proxy, opts.excludepkgs,
                              not opts.noverifyssl)
 
@@ -235,7 +240,7 @@ def main(args):
               remove_temp=True)
 
 
-def get_yum_base_object(installroot, repositories, mirrorlists=[],
+def get_yum_base_object(installroot, repositories, mirrorlists=[], repo_files=[],
                         tempdir="/var/tmp", proxy=None, excludepkgs=[],
                         sslverify=True):
 
@@ -285,13 +290,15 @@ def get_yum_base_object(installroot, repositories, mirrorlists=[],
     map(lambda (key, value): c.set(section, key, value), data.items())
 
     # add the main repository - the first repository from list
-    section = "lorax-repo"
-    data = {"name": "lorax repo",
-            "baseurl": repositories[0],
-            "enabled": 1}
+    # This list may be empty if using --repo to load .repo files
+    if repositories:
+        section = "lorax-repo"
+        data = {"name": "lorax repo",
+                "baseurl": repositories[0],
+                "enabled": 1}
 
-    c.add_section(section)
-    map(lambda (key, value): c.set(section, key, value), data.items())
+        c.add_section(section)
+        map(lambda (key, value): c.set(section, key, value), data.items())
 
     # add the extra repositories
     for n, extra in enumerate(repositories[1:], start=1):
@@ -329,6 +336,11 @@ def get_yum_base_object(installroot, repositories, mirrorlists=[],
     yb.preconf.errorlevel = 6
     yb.logger.setLevel(logging.DEBUG)
     yb.verbose_logger.setLevel(logging.DEBUG)
+
+    # Add .repo files from the cmdline
+    for fn in repo_files:
+        if os.path.exists(fn):
+            yb.getReposFromConfigFile(fn)
 
     return yb
 


### PR DESCRIPTION
This will allow anaconda to fetch kickstarts using https when installing
with fips=1

Leave vmlinuz and .vmlinuz.hmac in /boot

dracut-fips module needs the vmlinuz.hmac file in order to boot.

Resolves: rhbz#1341280