### PR TITLE
Fix systemctl command (#1478247)

### DIFF
--- a/README.livemedia-creator
+++ b/README.livemedia-creator
@@ -87,6 +87,15 @@ iso using GNOME, and the other to create a minimal disk image. When creating you
 own kickstarts you should start with the minimal example, it includes several
 needed packages that are not always included by dependencies.
 
+livemedia-creator parses the 'part /' entry to determine how big a disk image
+needs to be created. This means that the common kickstart technique of using
+%pre to generate a partition scheme for use with %include will not work. There
+needs to be a 'part /' entry in the main part of the kickstart.
+
+Only one kickstart file is supported, so if your kickstart is built from a
+number of %include commands it needs to be flattened into a single file with
+ksflatten first.
+
 Or you can use existing spin kickstarts to create live media with a few
 changes. Here are the steps I used to convert the Fedora XFCE spin.
 

--- a/docs/lorax.1
+++ b/docs/lorax.1
@@ -3,7 +3,7 @@
 lorax \- Create installer boot iso
 
 .SH SYNOPSIS
-lorax -p PRODUCT -v VERSION -r RELEASE -s REPOSITORY OUTPUTDIR
+lorax -p PRODUCT -v VERSION -r RELEASE [-s REPOSITORY|--repo CONFIG] OUTPUTDIR
 
 .SH DESCRIPTION
 
@@ -36,6 +36,10 @@ release information
 .TP
 \fB\-s REPOSITORY, \-\-source=REPOSITORY\fR
 source repository (may be listed multiple times)
+
+.TP
+\fB\--repo CONFIG\fR
+repository configuration file (may be listed multiple times)
 
 .SH
 OPTIONAL ARGUMENTS:
@@ -88,6 +92,10 @@ Path to logfile
 .TP
 \fB\-\-tmp=TMP\fR
 Top level temporary directory
+
+.TP
+\fB\-\-noverifyssl\fR
+This disables SSL certificate checking. eg. to allow using https: sources with self-signed certificates.
 
 .SH AUTHORS
 .nf

--- a/docs/rhel7-livemedia.ks
+++ b/docs/rhel7-livemedia.ks
@@ -369,4 +369,5 @@ syslinux
 
 # This package is needed to boot the iso on UEFI
 grub2-efi-*-cdboot
+grub2-efi-ia32
 %end

--- a/docs/rhel7-minimal.ks
+++ b/docs/rhel7-minimal.ks
@@ -56,6 +56,7 @@ syslinux
 
 # Boot on 32bit UEFI
 shim-ia32
+grub2-efi-ia32
 
 # NOTE: To build a bootable UEFI disk image livemedia-creator needs to be
 #       run on a UEFI system or virt.

--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -67,7 +67,7 @@ removepkg tigervnc-license ttmkfdir xml-common xorg-x11-font-utils
 removepkg xorg-x11-server-common yum-utils
 
 ## other removals
-remove /boot /home /media /opt /srv /tmp/*
+remove /home /media /opt /srv /tmp/*
 remove /usr/etc /usr/games /usr/local /usr/tmp
 remove /usr/share/doc /usr/share/info /usr/share/man /usr/share/gnome
 remove /usr/share/mime/application /usr/share/mime/audio /usr/share/mime/image
@@ -346,6 +346,11 @@ removefrom subscription-manager --allbut /etc/rhsm/* /usr/share/rhsm/* /var/log/
 ## cleanup_python_files()
 runcmd find ${root} -name "*.pyo" -type f -delete
 runcmd find ${root} -name "*.pyc" -type f -exec ln -sf /dev/null {} \;
+
+## cleanup /boot/ leaving vmlinuz, and .*hmac files
+runcmd chroot ${root} find /boot \! -name "vmlinuz*" \
+                            -and \! -name ".vmlinuz*" \
+                            -and \! -name boot -delete
 
 ## remove any broken links in /etc or /usr
 ## (broken systemd service links lead to confusing noise at boot)

--- a/share/runtime-install.tmpl
+++ b/share/runtime-install.tmpl
@@ -53,7 +53,7 @@ installpkg kernel
 installpkg plymouth
 
 ## extra dracut modules
-installpkg anaconda-dracut dracut-network dracut-config-generic
+installpkg anaconda-dracut dracut-network dracut-config-generic dracut-fips
 
 ## redhat-upgrade-dracut handles upgrades on RHEL
 installpkg redhat-upgrade-dracut redhat-upgrade-dracut-plymouth

--- a/share/runtime-postinstall.tmpl
+++ b/share/runtime-postinstall.tmpl
@@ -43,6 +43,9 @@ systemctl mask rhel-configure.service rhel-loadmodules.service \
                rhel-wait-storage.service media.mount \
                systemd-tmpfiles-clean.service systemd-tmpfiles-clean.timer
 
+## remove because it cannot be disabled
+remove usr/lib/systemd/system-generators/lvm2-activation-generator
+
 ## Make logind activate anaconda-shell@.service on switch to empty VT
 symlink anaconda-shell@.service lib/systemd/system/autovt@.service
 replace "#ReserveVT=6" "ReserveVT=2" etc/systemd/logind.conf

--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -49,6 +49,14 @@ from treeinfo import TreeInfo
 from discinfo import DiscInfo
 from executils import runcmd, runcmd_output
 
+# get lorax version
+try:
+    import pylorax.version
+except ImportError:
+    vernum = "devel"
+else:
+    vernum = pylorax.version.num
+
 # List of drivers to remove on ppc64 arch to keep initrd < 32MiB
 REMOVE_PPC64_DRIVERS = "floppy scsi_debug nouveau radeon cirrus mgag200"
 REMOVE_PPC64_MODULES = "drm plymouth"
@@ -154,14 +162,6 @@ class Lorax(BaseLoraxClass):
         assert self._configured
 
         installpkgs = installpkgs or []
-
-        # get lorax version
-        try:
-            import pylorax.version
-        except ImportError:
-            vernum = "devel"
-        else:
-            vernum = pylorax.version.num
 
         if domacboot:
             try:

--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -311,7 +311,7 @@ class Lorax(BaseLoraxClass):
                                   workdir=self.workdir)
 
         logger.info("rebuilding initramfs images")
-        dracut_args = ["--xz", "--install", "/.buildstamp", "--no-early-microcode"]
+        dracut_args = ["--xz", "--install", "/.buildstamp", "--no-early-microcode", "--add", "fips"]
         anaconda_args = dracut_args + ["--add", "anaconda pollcdrom"]
 
         # ppc64 cannot boot an initrd > 32MiB so remove some drivers

--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -642,11 +642,13 @@ class LoraxTemplateRunner(object):
             logger.debug("systemctl: no units given for %s, ignoring", cmd)
             return
         self.mkdir("/run/systemd/system") # XXX workaround for systemctl bug
-        systemctl = ('systemctl', '--root', self.outroot, '--no-reload',
-                     '--quiet', cmd)
+        systemctl = ['systemctl', '--root', self.outroot, '--no-reload',
+                     cmd]
+        # When a unit doesn't exist systemd aborts the command. Run them one at a time.
         # XXX for some reason 'systemctl enable/disable' always returns 1
-        try:
-            cmd = systemctl + units
-            runcmd(cmd)
-        except CalledProcessError:
-            pass
+        for unit in units:
+            try:
+                cmd = systemctl + [unit]
+                runcmd(cmd)
+            except CalledProcessError:
+                pass

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -48,7 +48,7 @@ from mako.template import Template
 from mako.exceptions import text_error_template
 
 # Use the Lorax treebuilder branch for iso creation
-from pylorax import ArchData
+from pylorax import ArchData, vernum
 from pylorax.base import DataHolder
 from pylorax.treebuilder import TreeBuilder, RuntimeBuilder, udev_escape
 from pylorax.treebuilder import findkernels
@@ -64,6 +64,8 @@ try:
     import libvirt
 except ImportError:
     libvirt = None
+
+VERSION = "{0}-{1}".format(os.path.basename(sys.argv[0]), vernum)
 
 # Default parameters for rebuilding initramfs, override with --dracut-args
 DRACUT_DEFAULT = ["--xz", "--add", "livenet dmsquash-live convertfs pollcdrom",
@@ -1136,10 +1138,16 @@ if __name__ == '__main__':
     parser.add_argument( "--squashfs_args",
                          help="additional squashfs args" )
 
+    # add the show version option
+    parser.add_argument("-V", help="show program's version number and exit",
+                        action="version", version=VERSION)
+
+    # parse the arguments
     opts = parser.parse_args()
 
     setup_logging(opts)
 
+    log.info("livemedia-creator %s", vernum)
     log.debug( opts )
 
     if os.getuid() != 0:

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -42,6 +42,8 @@ import yum
 yum.logginglevels._added_handlers = True
 import pylorax
 
+VERSION = "{0}-{1}".format(os.path.basename(sys.argv[0]), pylorax.vernum)
+
 def setup_logging(opts):
     # Setup logging to console and to logfile
     log.setLevel(logging.DEBUG)
@@ -77,14 +79,6 @@ def setup_logging(opts):
 
 
 def main(args):
-    # get lorax version
-    try:
-        from pylorax import version
-        vernum = version.num
-    except ImportError:
-        vernum = "devel"
-
-    version = "{0}-{1}".format(os.path.basename(args[0]), vernum)
     usage = "%prog -p PRODUCT -v VERSION -r RELEASE -s REPOSITORY OUTPUTDIR"
 
     parser = OptionParser(usage=usage)
@@ -161,13 +155,13 @@ def main(args):
 
     # add the show version option
     parser.add_option("-V", help="show program's version number and exit",
-            action="store_true", default=False, dest="showver")
+            action="store_true", dest="showver")
 
     # parse the arguments
     opts, args = parser.parse_args()
 
     if opts.showver:
-        print(version)
+        print(VERSION)
         sys.exit(0)
 
     try:
@@ -190,6 +184,7 @@ def main(args):
 
     setup_logging(opts)
 
+    log.info("Lorax %s", pylorax.vernum)
     tempfile.tempdir = opts.tmp
 
     # create the temporary directory for lorax

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -31,6 +31,7 @@ yum_log = logging.getLogger("yum")
 
 import sys
 import os
+import shutil
 import tempfile
 from optparse import OptionParser, OptionGroup
 import ConfigParser
@@ -99,6 +100,9 @@ def main(args):
     required.add_option("-s", "--source",
             help="source repository (may be listed multiple times)",
             metavar="REPOSITORY", action="append", default=[])
+    required.add_option("--repo",
+            help="source yum repository file",
+            dest="repo_files", metavar="REPOSITORY", action="append", default=[])
 
     # optional arguments
     optional = OptionGroup(parser, "optional arguments")
@@ -173,7 +177,7 @@ def main(args):
 
     # check for the required arguments
     if not opts.product or not opts.version or not opts.release \
-            or not opts.source or not outputdir:
+            or not (opts.source or opts.repo_files) or not outputdir:
         parser.error("missing one or more required arguments")
 
     if os.path.exists(outputdir):
@@ -198,6 +202,7 @@ def main(args):
     os.mkdir(yumtempdir)
 
     yb = get_yum_base_object(installtree, opts.source, opts.mirrorlist,
+                             opts.repo_files,
                              yumtempdir, opts.proxy, opts.excludepkgs,
                              not opts.noverifyssl)
 
@@ -235,7 +240,7 @@ def main(args):
               remove_temp=True)
 
 
-def get_yum_base_object(installroot, repositories, mirrorlists=[],
+def get_yum_base_object(installroot, repositories, mirrorlists=[], repo_files=[],
                         tempdir="/var/tmp", proxy=None, excludepkgs=[],
                         sslverify=True):
 
@@ -285,13 +290,15 @@ def get_yum_base_object(installroot, repositories, mirrorlists=[],
     map(lambda (key, value): c.set(section, key, value), data.items())
 
     # add the main repository - the first repository from list
-    section = "lorax-repo"
-    data = {"name": "lorax repo",
-            "baseurl": repositories[0],
-            "enabled": 1}
+    # This list may be empty if using --repo to load .repo files
+    if repositories:
+        section = "lorax-repo"
+        data = {"name": "lorax repo",
+                "baseurl": repositories[0],
+                "enabled": 1}
 
-    c.add_section(section)
-    map(lambda (key, value): c.set(section, key, value), data.items())
+        c.add_section(section)
+        map(lambda (key, value): c.set(section, key, value), data.items())
 
     # add the extra repositories
     for n, extra in enumerate(repositories[1:], start=1):
@@ -329,6 +336,11 @@ def get_yum_base_object(installroot, repositories, mirrorlists=[],
     yb.preconf.errorlevel = 6
     yb.logger.setLevel(logging.DEBUG)
     yb.verbose_logger.setLevel(logging.DEBUG)
+
+    # Add .repo files from the cmdline
+    for fn in repo_files:
+        if os.path.exists(fn):
+            yb.getReposFromConfigFile(fn)
 
     return yb
 


### PR DESCRIPTION
When multiple units are passed to systemctl and one fails it doesn't
finish the others. Change the template command to call systemctl for
each unit individually.

This also removes the lvm2-activation-generator in runtime-cleanup.tmpl

Resolves: rhbz#1478247