### PR TITLE
[fedora-27] Make 64-bit kernel on 32-bit firmware work for x86 efi machines

### DIFF
--- a/share/templates.d/99-generic/aarch64.tmpl
+++ b/share/templates.d/99-generic/aarch64.tmpl
@@ -37,7 +37,8 @@ mkdir ${KERNELDIR}
 <% efiargs=""; efigraft="" %>
 %if exists("boot/efi/EFI/*/gcdaa64.efi"):
     <%
-    efiarch = 'AA64'
+    efiarch32 = None
+    efiarch64 = 'AA64'
     efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
     images = ["images/efiboot.img"]
     %>
@@ -48,7 +49,7 @@ mkdir ${KERNELDIR}
         %>
         treeinfo images-${basearch} ${img|basename} ${img}
     %endfor
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel"/>
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=efiarch32, efiarch64=efiarch64, isolabel=isolabel"/>
 %endif
 
 # Create optional product.img and updates.img

--- a/share/templates.d/99-generic/efi.tmpl
+++ b/share/templates.d/99-generic/efi.tmpl
@@ -1,4 +1,4 @@
-<%page args="configdir, KERNELDIR, efiarch, isolabel"/>
+<%page args="configdir, KERNELDIR, efiarch32, efiarch64, isolabel"/>
 <%
 EFIBOOTDIR="EFI/BOOT"
 APPLE_EFI_ICON=inroot+"/usr/share/pixmaps/bootloader/fedora.icns"
@@ -7,9 +7,16 @@ APPLE_EFI_DISKNAME=inroot+"/usr/share/pixmaps/bootloader/fedora-media.vol"
 
 mkdir ${EFIBOOTDIR}
 mkdir ${EFIBOOTDIR}/fonts/
-install boot/efi/EFI/*/shim.efi ${EFIBOOTDIR}/BOOT${efiarch}.EFI
-install boot/efi/EFI/*/MokManager.efi ${EFIBOOTDIR}/
-install boot/efi/EFI/*/gcd${efiarch|lower}.efi ${EFIBOOTDIR}/grub${efiarch|lower}.efi
+%if efiarch64:
+install boot/efi/EFI/*/shim${efiarch64|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch64}.EFI
+install boot/efi/EFI/*/mm${efiarch64|lower}.efi ${EFIBOOTDIR}/
+install boot/efi/EFI/*/gcd${efiarch64|lower}.efi ${EFIBOOTDIR}/grub${efiarch64|lower}.efi
+%endif
+%if efiarch32:
+install boot/efi/EFI/*/shim${efiarch32|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch32}.EFI
+install boot/efi/EFI/*/mm${efiarch32|lower}.efi ${EFIBOOTDIR}/
+install boot/efi/EFI/*/gcd${efiarch32|lower}.efi ${EFIBOOTDIR}/grub${efiarch32|lower}.efi
+%endif
 install boot/efi/EFI/*/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
 
 ## actually make the EFI images
@@ -43,7 +50,7 @@ ${make_efiboot("images/efiboot.img")}
     %else:
         replace @ROOT@ 'inst.stage2=hd:LABEL=${isolabel|udev}' ${eficonf}
     %endif
-    %if efiarch == 'IA32':
+    %if efiarch32 == 'IA32':
         copy ${eficonf} ${EFIBOOTDIR}/BOOT.conf
     %endif
     runcmd mkefiboot ${args} ${outroot}/${EFIBOOTDIR} ${outroot}/${img}

--- a/share/templates.d/99-generic/live/aarch64.tmpl
+++ b/share/templates.d/99-generic/live/aarch64.tmpl
@@ -43,7 +43,8 @@ mkdir ${KERNELDIR}
 <% efiargs=""; efigraft="" %>
 %if exists("boot/efi/EFI/*/gcdaa64.efi"):
     <%
-    efiarch = 'AA64'
+    efiarch32 = None
+    efiarch64 = 'AA64'
     efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
     images = ["images/efiboot.img"]
     %>
@@ -54,7 +55,7 @@ mkdir ${KERNELDIR}
         %>
         treeinfo images-${basearch} ${img|basename} ${img}
     %endfor
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel"/>
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=efiarch32, efiarch64=efiarch64, isolabel=isolabel"/>
 %endif
 
 # Create optional product.img and updates.img

--- a/share/templates.d/99-generic/live/efi.tmpl
+++ b/share/templates.d/99-generic/live/efi.tmpl
@@ -1,4 +1,4 @@
-<%page args="configdir, KERNELDIR, efiarch, isolabel"/>
+<%page args="configdir, KERNELDIR, efiarch32, efiarch64, isolabel"/>
 <%
 EFIBOOTDIR="EFI/BOOT"
 APPLE_EFI_ICON=inroot+"/usr/share/pixmaps/bootloader/fedora.icns"
@@ -7,9 +7,16 @@ APPLE_EFI_DISKNAME=inroot+"/usr/share/pixmaps/bootloader/fedora-media.vol"
 
 mkdir ${EFIBOOTDIR}
 mkdir ${EFIBOOTDIR}/fonts/
-install boot/efi/EFI/*/shim.efi ${EFIBOOTDIR}/BOOT${efiarch}.EFI
-install boot/efi/EFI/*/MokManager.efi ${EFIBOOTDIR}/
-install boot/efi/EFI/*/gcd${efiarch|lower}.efi ${EFIBOOTDIR}/grub${efiarch|lower}.efi
+%if efiarch64:
+install boot/efi/EFI/*/shim${efiarch64|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch64}.EFI
+install boot/efi/EFI/*/mm${efiarch64|lower}.efi ${EFIBOOTDIR}/
+install boot/efi/EFI/*/gcd${efiarch64|lower}.efi ${EFIBOOTDIR}/grub${efiarch64|lower}.efi
+%endif
+%if efiarch32:
+install boot/efi/EFI/*/shim${efiarch32|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch32}.EFI
+install boot/efi/EFI/*/mm${efiarch32|lower}.efi ${EFIBOOTDIR}/
+install boot/efi/EFI/*/gcd${efiarch32|lower}.efi ${EFIBOOTDIR}/grub${efiarch32|lower}.efi
+%endif
 install boot/efi/EFI/*/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
 
 ## actually make the EFI images
@@ -43,7 +50,7 @@ ${make_efiboot("images/efiboot.img")}
     %else:
         replace @ROOT@ 'root=live:CDLABEL=${isolabel|udev}' ${eficonf}
     %endif
-    %if efiarch == 'IA32':
+    %if efiarch32 == 'IA32':
         copy ${eficonf} ${EFIBOOTDIR}/BOOT.conf
     %endif
     runcmd mkefiboot ${args} ${outroot}/${EFIBOOTDIR} ${outroot}/${img}

--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -69,11 +69,15 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %endif
 
 ## WHeeeeeeee, EFI.
-## We could remove the basearch restriction someday..
-<% efiargs=""; efigraft=""; efihybrid="" %>
-%if exists("boot/efi/EFI/fedora/gcdx64.efi") and basearch != 'i386':
+<% efiargs=""; efigraft=""; efihybrid=""; efiarch32=None; efiarch64=None %>
+%if exists("boot/efi/EFI/*/gcdia32.efi"):
+    <% efiarch32 = 'IA32' %>
+%endif
+%if exists("boot/efi/EFI/*/gcdx64.efi"):
+    <% efiarch64 = 'X64' %>
+%endif
+%if efiarch32 or efiarch64:
     <%
-    efiarch = 'X64' if basearch=='x86_64' else 'IA32'
     efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
     images = ["images/efiboot.img"]
     if domacboot:
@@ -87,7 +91,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
         treeinfo images-${basearch} ${img|basename} ${img}
     %endfor
     <% efihybrid = "--uefi --mac" if domacboot else "--uefi" %>
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel"/>
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=efiarch32, efiarch64=efiarch64, isolabel=isolabel"/>
 %endif
 
 # Create optional product.img and updates.img

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -34,7 +34,7 @@ installpkg glibc-all-langpacks
 
 ## arch-specific packages (bootloaders etc.)
 %if basearch == "aarch64":
-    installpkg efibootmgr grub2-efi grub2-efi-modules grub2-tools shim shim-unsigned
+    installpkg efibootmgr grub2-efi-aa64-cdboot grubby shim-aa64
 %endif
 %if basearch in ("arm", "armhfp"):
     installpkg kernel-lpae
@@ -44,13 +44,18 @@ installpkg glibc-all-langpacks
     installpkg kernel-PAE gpart
 %endif
 %if basearch == "x86_64":
-    installpkg efibootmgr grub2-efi grub2-efi-modules shim shim-unsigned
+    installpkg grub2-tools-efi
+    installpkg shim-x64 grub2-efi-x64-cdboot
 %endif
 %if basearch in ("i386", "x86_64"):
-    installpkg grub2 grub2-tools memtest86+ syslinux syslinux-nonlinux
+    installpkg biosdevname memtest86+ syslinux
+    installpkg efibootmgr
+    installpkg shim-ia32 grub2-efi-ia32-cdboot
 %endif
 %if basearch in ("ppc", "ppc64", "ppc64le"):
-    installpkg grub2 grub2-tools fbset hfsutils kernel-bootwrapper ppc64-utils ppc64-diag
+    installpkg fbset hfsutils kernel-bootwrapper ppc64-utils ppc64-diag
+    installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
+    installpkg grub2-${basearch}
 %endif
 %if basearch == "s390x":
     installpkg lsscsi s390utils-base s390utils-cmsfs-fuse

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -71,11 +71,15 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %endif
 
 ## WHeeeeeeee, EFI.
-## We could remove the basearch restriction someday..
-<% efiargs=""; efigraft=""; efihybrid="" %>
-%if exists("boot/efi/EFI/*/gcdx64.efi") and basearch != 'i386':
+<% efiargs=""; efigraft=""; efihybrid=""; efiarch32=None %>
+%if exists("boot/efi/EFI/*/gcdia32.efi"):
+    <% efiarch32 = 'IA32' %>
+%endif
+%if exists("boot/efi/EFI/*/gcdx64.efi"):
+    <% efiarch64 = 'X64' %>
+%endif
+%if efiarch32 or efiarch64:
     <%
-    efiarch = 'X64' if basearch=='x86_64' else 'IA32'
     efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
     images = ["images/efiboot.img"]
     if domacboot:
@@ -89,7 +93,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
         treeinfo images-${basearch} ${img|basename} ${img}
     %endfor
     <% efihybrid = "--uefi --mac" if domacboot else "--uefi" %>
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel"/>
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=efiarch32, efiarch64=efiarch64, isolabel=isolabel"/>
 %endif
 
 # Create optional product.img and updates.img


### PR DESCRIPTION
This enables Baytrail and similar atom CPUs that typically ship with a
32-bit firmware, but have a 64-bit capable CPU.

Signed-off-by: Peter Jones <pjones@redhat.com>