### PR TITLE
Don't install rdma bits on 32-bit ARM (#1483278)

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -122,7 +122,10 @@ installpkg hdparm
 %if basearch not in ("aarch64", "ppc64le", "s390x"):
 installpkg pcmciautils
 %endif
-installpkg libmlx4 rdma
+## see bug #1483278
+%if basearch not in ("arm", "armhfp"):
+    installpkg libmlx4 rdma-core
+%endif
 installpkg rng-tools
 
 ## fonts & themes


### PR DESCRIPTION
Per dledford, RDMA fundamentally cannot work reliably on 32-bit
ARM arches, so as part of the re-organization of the relevant
packages, building them on 32-bit ARM has been disabled (for
F27+). Thus we should adjust lorax not to try and install them
on 32-bit ARM. Also change the package name, the 'rdma' package
is obsoleted by 'rdma-core'. This commit should not be applied
to branches for older distros.

Signed-off-by: Adam Williamson <awilliam@redhat.com>