### PR TITLE
Fix grub2-efi-ia32-cdboot and shim-ia32 bits.

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -45,12 +45,12 @@ installpkg glibc-all-langpacks
 %endif
 %if basearch == "x86_64":
     installpkg grub2-tools-efi
+    installpkg efibootmgr
     installpkg shim-x64 grub2-efi-x64-cdboot
+    installpkg shim-ia32 grub2-efi-ia32-cdboot
 %endif
 %if basearch in ("i386", "x86_64"):
     installpkg biosdevname memtest86+ syslinux
-    installpkg efibootmgr
-    installpkg shim-ia32 grub2-efi-ia32-cdboot
 %endif
 %if basearch in ("ppc", "ppc64", "ppc64le"):
     installpkg fbset hfsutils kernel-bootwrapper ppc64-utils ppc64-diag


### PR DESCRIPTION
These should be x86_64 only, because that's what the packages are.

Signed-off-by: Peter Jones <pjones@redhat.com>