### PR TITLE
x86.tmpl: ensure efiarch64 is defined

### DIFF
--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -71,7 +71,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %endif
 
 ## WHeeeeeeee, EFI.
-<% efiargs=""; efigraft=""; efihybrid=""; efiarch32=None %>
+<% efiargs=""; efigraft=""; efihybrid=""; efiarch32=None; efiarch64=None %>
 %if exists("boot/efi/EFI/*/gcdia32.efi"):
     <% efiarch32 = 'IA32' %>
 %endif


### PR DESCRIPTION
pjones missed an initial definition for this variable, so i686
composes are failing with 'referenced before assignment':

https://koji.fedoraproject.org/koji/taskinfo?taskID=21459938