### PR TITLE
x86.tmpl: initially define compressargs as empty string

### DIFF
--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -95,7 +95,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %endif
 
 # Create optional product.img and updates.img
-<% filegraft=""; images=["product", "updates"]; compressargs=None; %>
+<% filegraft=""; images=["product", "updates"]; compressargs=""; %>
 %if basearch == 'i386':
     # Limit the amount of memory xz uses on i386
     <% compressargs="--xz -9 --memlimit-compress=3700MiB" %>

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -97,7 +97,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %endif
 
 # Create optional product.img and updates.img
-<% filegraft=""; images=["product", "updates"]; compressargs=None; %>
+<% filegraft=""; images=["product", "updates"]; compressargs=""; %>
 %if basearch == 'i386':
     # Limit the amount of memory xz uses on i386
     <% compressargs="--xz -9 --memlimit-compress=3700MiB" %>


### PR DESCRIPTION
pjones and I happened to notice this suspicious line in the
lmc log for a Fedora 27 live image compose:

2017-08-25 16:04:55,327 DEBUG pylorax.ltmpl: template line 25: installimg None usr/share/lorax//product/ images/product.img

That 'None' does not look right. I believe this is the problem.
The command is defined as `installimg ${compressargs} ...`, and
a few lines earlier, `compressargs` is initially assigned (in
Python) as `None`. `None`, in Python, stringifies to the string
'None'. So unless we're on i386 (where `compressargs` gets
defined to an actual string of arguments in a conditional), we
wind up passing in the string 'None' as the first arg to the
`installimg` command.

To fix this, `compressargs` should be initially set to the empty
string rather than `None`.