### PR TITLE
Restore all of the grub2-tools on x86_64 and i386 (#1492197)

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -51,6 +51,7 @@ installpkg glibc-all-langpacks
 %endif
 %if basearch in ("i386", "x86_64"):
     installpkg biosdevname memtest86+ syslinux
+    installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
 %endif
 %if basearch in ("ppc", "ppc64", "ppc64le"):
     installpkg fbset hfsutils kernel-bootwrapper ppc64-utils ppc64-diag


### PR DESCRIPTION
These can be useful during installation or rescue.
(They are already present on ppc64)