### PR TITLE
Silence pocketlint bad-preconf-access warnings

### DIFF
--- a/src/pylorax/api/yumbase.py
+++ b/src/pylorax/api/yumbase.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+# pylint: disable=bad-preconf-access
+
 import logging
 log = logging.getLogger("lorax-composer")
 

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -19,6 +19,8 @@
 #
 # Red Hat Author(s):  Martin Gracik <mgracik@redhat.com>
 #
+# pylint: disable=bad-preconf-access
+
 from __future__ import print_function
 
 import logging
@@ -331,7 +333,6 @@ def get_yum_base_object(installroot, repositories, mirrorlists=None, repo_files=
 
     yb.preconf.fn = yumconf
     yb.preconf.root = installroot
-    #yb.repos.setCacheDir(cachedir)
     if releasever:
         yb.preconf.releasever = releasever
 


### PR DESCRIPTION
Note: the problem that pocketlint is trying to warn us about lies
in YumBase._getConfig() method because it deletes the preconf
attribute from the object (self) which can cause exceptions!

- there is a YumBase.doConfigSetup() method so use it, even though
  it has been deprecated. There doesn't seem to be an alternative!
- doConfigSetup() doesn't accept releasever as parameter so we
  disable pylint for this line!