### PR TITLE
Log a more descriptive error when setfiles fails (#1499771)

### DIFF
--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -119,7 +119,13 @@ def mkrootfsimg(rootdir, outfile, label, size=2, sysroot=""):
                     "-e", "/install", "-e", "/ostree",
                     "/etc/selinux/targeted/contexts/files/file_contexts", "/"]
             root = join(mnt, sysroot.lstrip("/"))
-            runcmd(cmd, root=root)
+            try:
+                runcmd(cmd, root=root)
+            except CalledProcessError as e:
+                logger.error("setfiles exited with a non-zero return code (%d) which may "
+                             "be caused by running without SELinux in Permissive mode.", e.returncode)
+                raise
+
 
 ######## Utility functions ###############################################
 


### PR DESCRIPTION
Some lorax users run it from inside mock, which isn't able to detect
whether the host is in Permissive mode. This can lead to confusing
error messages, so this points them in the right direction.