### PR TITLE
Enable lorax-composer testing in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: required
+language: python
+services:
+  - docker
+
+script:
+  - make test-in-docker
+
+after_success:
+  - |
+
+        sudo docker create --name results-cont welder/lorax-composer
+        sudo docker cp results-cont:/lorax/.coverage .coverage
+        sudo docker rm results-cont
+
+        pip install coveralls
+        coveralls
+
+notifications:
+  email:
+    on_failure: change
+    on_success: never

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,21 @@
+FROM centos:7
+
+COPY epel.repo /etc/yum.repos.d/
+RUN yum -y install --nogpgcheck epel-release && \
+    rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-* && \
+    yum -y install make libgit2-glib tito python-pylint  \
+                    python-nose python-mako python-flask \
+                    python-coverage libselinux-python    \
+                    pykickstart python2-pytoml \
+                    python2-mock python-semantic_version && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+
+RUN mkdir /lorax
+COPY Makefile /lorax
+COPY src/ /lorax/src
+COPY tests/ /lorax/tests
+
+WORKDIR /lorax
+RUN make test

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ local:
 	@rm -rf /var/tmp/$(PKGNAME)-$(VERSION)
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 
+test-in-docker:
+	sudo docker build -t welder/lorax-composer:latest -f Dockerfile.test .
+
 ci: check test
 
 .PHONY: all install check test clean tag docs archive local

--- a/epel.repo
+++ b/epel.repo
@@ -1,0 +1,8 @@
+[epel]
+name=Extra Packages for Enterprise Linux 7 - $basearch
+#baseurl=http://download.fedoraproject.org/pub/epel/7/$basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7


### PR DESCRIPTION
After a comment from Martin Pitt I think we can still make use of Travis CI for things that are easier to test there and use Jenkins as a triggering system for scenarios which aren't possible in Travis or require internal infrastructure. This PR enables testing using Docker container built from the official CentOS 7 image.

Also I will need someone with more permissions to enable the builds at:
https://travis-ci.org/rhinstaller/lorax