### PR TITLE
Properly report coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+# http://nedbatchelder.com/code/coverage/config.html
+
+[paths]
+source = .
+        /lorax/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,11 @@ after_success:
   - |
 
         sudo docker create --name results-cont welder/lorax-composer
-        sudo docker cp results-cont:/lorax/.coverage .coverage
+        sudo docker cp results-cont:/lorax/.coverage .coverage.docker
         sudo docker rm results-cont
 
-        pip install coveralls
+        pip install coverage==3.6 coveralls
+        coverage combine
         coveralls
 
 notifications:


### PR DESCRIPTION
- use same version of coverage.py as is inside the container b/c
  data format has changed between versions
- use `coverage combine' with a .coveragerc mapping to adjust for
  differences in file paths between the container and Travis