### PR TITLE
Don't try and install kernel-PAE on i686 any more

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -41,7 +41,7 @@ installpkg glibc-all-langpacks
     installpkg uboot-tools
 %endif
 %if basearch == "i386":
-    installpkg kernel-PAE gpart
+    installpkg gpart
 %endif
 %if basearch == "x86_64":
     installpkg grub2-tools-efi


### PR DESCRIPTION
kernel-PAE has been intentionally removed from Rawhide kernel
builds; Fedora 27 will be the last release with kernel-PAE for
i686. So we need to not try and install it in future. See
http://pkgs.fedoraproject.org/rpms/kernel/c/21e4b8338 (it's a
big commit, but the change is in there, it's the second change
in kernel.spec).

Signed-off-by: Adam Williamson <awilliam@redhat.com>