### PR TITLE
LMC: Make the QEMU RNG device optional

### DIFF
--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -243,6 +243,8 @@ def lmc_parser(dracut_default=""):
                             help="Use OVMF firmware to boot the VM in UEFI mode")
     virt_group.add_argument("--no-kvm", action="store_true", default=False,
                             help="Skip using kvm with qemu even if it is available.")
+    virt_group.add_argument("--with-rng", default="/dev/random",
+                            help="RNG device for QEMU (none for no RNG)")
 
     # dracut arguments
     dracut_group = parser.add_argument_group("dracut arguments")

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -242,8 +242,9 @@ class QEMUInstall(object):
         qemu_cmd += ["-chardev", "socket,id=charchannel0,host=%s,port=%s" % (virtio_host, virtio_port)]
 
         # PAss through rng from host
-        qemu_cmd += ["-object", "rng-random,id=virtio-rng0,filename=/dev/random"]
-        qemu_cmd += ["-device", "virtio-rng-pci,rng=virtio-rng0,id=rng0,bus=pci.0,addr=0x9"]
+        if opts.with_rng != "none":
+            qemu_cmd += ["-object", "rng-random,id=virtio-rng0,filename=%s" % opts.with_rng]
+            qemu_cmd += ["-device", "virtio-rng-pci,rng=virtio-rng0,id=rng0,bus=pci.0,addr=0x9"]
 
         if boot_uefi and ovmf_path:
             qemu_cmd += ["-drive", "file=%s/OVMF_CODE.fd,if=pflash,format=raw,unit=0,readonly=on" % ovmf_path]


### PR DESCRIPTION
Added a new QEMU argument '--with-rng' to specify a RNG device other
than /dev/random or "none".

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>