### PR TITLE
Replace fedora-gnome-theme with gnome-themes-standard (#1537573)

### DIFF
--- a/share/runtime-install.tmpl
+++ b/share/runtime-install.tmpl
@@ -141,7 +141,7 @@ installpkg xorg-x11-fonts-misc
 installpkg gnome-themes-standard gnome-icon-theme-legacy
 
 ## branding & logos
-installpkg fedora-gnome-theme
+installpkg gnome-themes-standard
 
 ## debugging/bug reporting tools
 installpkg gdb-gdbserver


### PR DESCRIPTION
gnome-themes-standard used to provide fedora-gnome-theme, but dropped it
in version 3.22.2-1

Resolves: rhbz#1537573