### PR TITLE
Don't try to build efi images for basearch=i386.

### DIFF
--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -76,7 +76,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %if exists("boot/efi/EFI/*/gcdx64.efi"):
     <% efiarch64 = 'X64' %>
 %endif
-%if efiarch32 or efiarch64:
+%if efiarch32 or efiarch64 and basearch != 'i386':
     <%
     efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
     images = ["images/efiboot.img"]

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -78,7 +78,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %if exists("boot/efi/EFI/*/gcdx64.efi"):
     <% efiarch64 = 'X64' %>
 %endif
-%if efiarch32 or efiarch64:
+%if efiarch32 or efiarch64 and basearch != 'i386':
     <%
     efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
     images = ["images/efiboot.img"]


### PR DESCRIPTION
This shouldn't have been turned on when we switched to doing ia32-efi
images on x86_64; just having the file available isn't where we want
that policy decision to be.

Resolves: rhbz#1539085

Signed-off-by: Peter Jones <pjones@redhat.com>