### PR TITLE
Add more tests for api.recipes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+.coverage

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,16 +6,14 @@ RUN yum -y install --nogpgcheck epel-release && \
     yum -y install make libgit2-glib tito python-pylint  \
                     python-nose python-mako python-flask \
                     python-coverage libselinux-python    \
-                    pykickstart python2-pytoml \
+                    pykickstart python2-pytoml python-sphinx \
                     python2-mock python-semantic_version && \
     yum clean all && \
     rm -rf /var/cache/yum
 
 
 RUN mkdir /lorax
-COPY Makefile /lorax
-COPY src/ /lorax/src
-COPY tests/ /lorax/tests
+COPY . /lorax
 
 WORKDIR /lorax
 RUN make test

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ check:
 	@echo "*** Running pylint ***"
 	PYTHONPATH=$(PYTHONPATH):./src/ ./tests/pylint/runpylint.py
 
-test:
+# /api/docs/ tests require we have the documentation already built
+test: docs
 	@echo "*** Running tests ***"
 	PYTHONPATH=$(PYTHONPATH):./src/ $(PYTHON) -m nose -v --with-coverage --cover-erase --cover-branches \
 			--cover-package=pylorax --cover-inclusive \

--- a/src/pylorax/api/yumbase.py
+++ b/src/pylorax/api/yumbase.py
@@ -22,6 +22,7 @@ log = logging.getLogger("lorax-composer")
 import ConfigParser
 from fnmatch import fnmatchcase
 from glob import glob
+from distutils.util import strtobool
 import os
 import yum
 # This is a hack to short circuit yum's internal logging
@@ -56,7 +57,7 @@ def get_base_object(conf):
     if conf.get_default("yum", "proxy", None):
         data["proxy"] = conf.get("yum", "proxy")
 
-    if conf.get_default("yum", "sslverify", None) == False:
+    if conf.has_option("yum", "sslverify") and not conf.getboolean("yum", "sslverify"):
         data["sslverify"] = "0"
 
     c.add_section(section)
@@ -93,7 +94,7 @@ def get_base_object(conf):
     # Gather up all the available repo files, add the ones matching "repos":"enabled" patterns
     enabled_repos = conf.get("repos", "enabled").split(",")
     repo_files = glob(joinpaths(repodir, "*.repo"))
-    if conf.get_default("repos", "use_system_repos", True):
+    if not conf.has_option("repos", "use_system_repos") or conf.getboolean("repos", "use_system_repos"):
         repo_files.extend(glob("/etc/yum.repos.d/*.repo"))
 
     for repo_file in repo_files:

--- a/tests/pylorax/test_projects.py
+++ b/tests/pylorax/test_projects.py
@@ -166,3 +166,23 @@ class ProjectsTest(unittest.TestCase):
         print(modules)
         self.assertEqual(modules[0]["name"], "bash")
         self.assertEqual(modules[0]["dependencies"][0]["name"], "basesystem")
+
+
+class ConfigureTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix="lorax.test.configure.")
+        self.conf_file = os.path.join(self.tmp_dir, 'test.conf')
+        open(self.conf_file, 'w').write("[composer]\ncache_dir = /tmp/cache-test")
+
+    @classmethod
+    def tearDownClass(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def test_configure_reads_existing_file(self):
+        config = configure(conf_file=self.conf_file)
+        self.assertEqual(config.get('composer', 'cache_dir'), '/tmp/cache-test')
+
+    def test_configure_reads_non_existing_file(self):
+        config = configure(conf_file=self.conf_file + '.non-existing')
+        self.assertEqual(config.get('composer', 'cache_dir'), '/var/tmp/composer/cache')

--- a/tests/pylorax/test_projects.py
+++ b/tests/pylorax/test_projects.py
@@ -15,15 +15,18 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import os
+import mock
 import time
 import shutil
 import tempfile
 import unittest
 
+from yum.Errors import YumBaseError
+
 from pylorax.api.config import configure, make_yum_dirs
 from pylorax.api.projects import api_time, api_changelog, yaps_to_project, yaps_to_project_info
 from pylorax.api.projects import tm_to_dep, yaps_to_module, projects_list, projects_info, projects_depsolve
-from pylorax.api.projects import modules_list, modules_info, ProjectsError, dep_evra
+from pylorax.api.projects import modules_list, modules_info, ProjectsError, dep_evra, dep_nevra, ProjectsError
 from pylorax.api.yumbase import get_base_object
 
 
@@ -71,7 +74,13 @@ class ProjectsTest(unittest.TestCase):
         self.assertEqual(api_time(499222800), "1985-10-27T01:00:00")
 
     def test_api_changelog(self):
-        self.assertEqual(api_changelog([[0,1,"Heavy!"]]), "Heavy!")
+        self.assertEqual(api_changelog([[0,1,"Heavy!"], [0, 1, "Light!"]]), "Heavy!")
+
+    def test_api_changelog_empty_list(self):
+        self.assertEqual(api_changelog([]), '')
+
+    def test_api_changelog_missing_text_entry(self):
+        self.assertEqual(api_changelog([('now', 'atodorov')]), '')
 
     def test_yaps_to_project(self):
         result = {"name":"name",
@@ -132,15 +141,41 @@ class ProjectsTest(unittest.TestCase):
                "version": "10.0"}
         self.assertEqual(dep_evra(dep), "10.0-7.el7.noarch")
 
+    def test_dep_evra_with_epoch_not_zero(self):
+        dep = {"arch": "x86_64",
+               "epoch": "2",
+               "name": "tog-pegasus-libs",
+               "release": "3.el7",
+               "version": "2.14.1"}
+        self.assertEqual(dep_evra(dep), "2:2.14.1-3.el7.x86_64")
+
+    def test_dep_nevra(self):
+        dep = {"arch": "noarch",
+               "epoch": "0",
+               "name": "basesystem",
+               "release": "7.el7",
+               "version": "10.0"}
+        self.assertEqual(dep_nevra(dep), "basesystem-10.0-7.el7.noarch")
+
     def test_projects_list(self):
         projects = projects_list(self.yb)
         self.assertEqual(len(projects) > 10, True)
+
+    def test_projects_list_yum_raises_exception(self):
+        with self.assertRaises(ProjectsError):
+            with mock.patch.object(self.yb, 'doPackageLists', side_effect=YumBaseError('TESTING')):
+                projects_list(self.yb)
 
     def test_projects_info(self):
         projects = projects_info(self.yb, ["bash"])
 
         self.assertEqual(projects[0]["name"], "bash")
         self.assertEqual(projects[0]["builds"][0]["source"]["license"], "GPLv3+")
+
+    def test_projects_info_yum_raises_exception(self):
+        with self.assertRaises(ProjectsError):
+            with mock.patch.object(self.yb, 'doPackageLists', side_effect=YumBaseError('TESTING')):
+                projects_info(self.yb, ["bash"])
 
     def test_projects_depsolve(self):
         deps = projects_depsolve(self.yb, ["bash"])
@@ -160,12 +195,22 @@ class ProjectsTest(unittest.TestCase):
         modules = modules_list(self.yb, ["g*"])
         self.assertEqual(modules[0]["name"].startswith("g"), True)
 
+    def test_modules_list_yum_raises_exception(self):
+        with self.assertRaises(ProjectsError):
+            with mock.patch.object(self.yb, 'doPackageLists', side_effect=YumBaseError('TESTING')):
+                modules_list(self.yb, None)
+
     def test_modules_info(self):
         modules = modules_info(self.yb, ["bash"])
 
         print(modules)
         self.assertEqual(modules[0]["name"], "bash")
         self.assertEqual(modules[0]["dependencies"][0]["name"], "basesystem")
+
+    def test_modules_info_yum_raises_exception(self):
+        with self.assertRaises(ProjectsError):
+            with mock.patch.object(self.yb, 'doPackageLists', side_effect=YumBaseError('TESTING')):
+                modules_info(self.yb, ["bash"])
 
 
 class ConfigureTest(unittest.TestCase):

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import os
 import shutil
 import tempfile
 from threading import Lock
@@ -52,6 +53,11 @@ class ServerTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         shutil.rmtree(server.config["REPO_DIR"])
+
+    def test_00_hello(self):
+        """Test /"""
+        resp = self.server.get("/")
+        self.assertEqual(resp.data, 'Hello, World!')
 
     def test_01_status(self):
         """Test the /api/v0/status route"""
@@ -484,3 +490,15 @@ class ServerTestCase(unittest.TestCase):
         recipes = data.get("recipes")
         self.assertEqual(len(recipes), 1)
         self.assertEqual(recipes[0], test_recipe)
+
+    def test_api_docs(self):
+        """Test the /api/docs/"""
+        resp = self.server.get("/api/docs/")
+        doc_str = open(os.path.abspath(joinpaths(os.path.dirname(__file__), "../../docs/html/index.html"))).read()
+        self.assertEqual(doc_str, resp.data)
+
+    def test_api_docs_with_existing_path(self):
+        """Test the /api/docs/modules.html"""
+        resp = self.server.get("/api/docs/modules.html")
+        doc_str = open(os.path.abspath(joinpaths(os.path.dirname(__file__), "../../docs/html/modules.html"))).read()
+        self.assertEqual(doc_str, resp.data)

--- a/tests/pylorax/test_workspace.py
+++ b/tests/pylorax/test_workspace.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import os
+import mock
 import shutil
 import tempfile
 import unittest
@@ -66,6 +67,13 @@ class WorkspaceTest(unittest.TestCase):
         recipe = workspace_read(self.repo, "master", "http-server")
         self.assertEqual(self.example_recipe, recipe)
 
+    def test_04_workspace_read_ioerror(self):
+        """Test the workspace_read function dealing with internal IOError"""
+        # The recipe was written by the workspace_write test.
+        with self.assertRaises(recipes.RecipeFileError):
+            with mock.patch('pylorax.api.workspace.recipe_from_toml', side_effect=IOError('TESTING')):
+                recipe = workspace_read(self.repo, "master", "http-server")
+
     def test_05_workspace_delete(self):
         """Test the workspace_delete function"""
         ws_recipe_path = joinpaths(self.repo_dir, "git", "workspace", "master", "http-server.toml")
@@ -73,3 +81,10 @@ class WorkspaceTest(unittest.TestCase):
         self.assertEqual(os.path.exists(ws_recipe_path), True)
         workspace_delete(self.repo, "master", "http-server")
         self.assertEqual(os.path.exists(ws_recipe_path), False)
+
+    def test_05_workspace_delete_non_existing(self):
+        """Test the workspace_delete function"""
+        ws_recipe_path = joinpaths(self.repo_dir, "git", "workspace", "master", "non-existing.toml")
+
+        workspace_delete(self.repo, "master", "non-existing")
+        self.assertFalse(os.path.exists(ws_recipe_path))

--- a/tests/pylorax/test_yumbase.py
+++ b/tests/pylorax/test_yumbase.py
@@ -1,0 +1,86 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import os
+import shutil
+import tempfile
+import unittest
+from glob import glob
+
+import ConfigParser
+
+from pylorax.api.config import configure, make_yum_dirs
+from pylorax.api.yumbase import get_base_object
+
+
+class YumbaseTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix="lorax.test.yumbase.")
+        conf_file = os.path.join(self.tmp_dir, 'test.conf')
+        open(conf_file, 'w').write("""[composer]
+# releasever different from the current default
+releasever = 6
+[yum]
+proxy = https://proxy.example.com
+sslverify = False
+[repos]
+use_system_repos = False
+""")
+
+        # will read the above configuration
+        config = configure(conf_file=conf_file, root_dir=self.tmp_dir)
+        make_yum_dirs(config)
+
+        # will read composer config and store a yum config file
+        self.yb = get_base_object(config)
+
+        # will read the stored yum config file
+        self.yumconf = ConfigParser.ConfigParser()
+        self.yumconf.read([config.get("composer", "yum_conf")])
+
+    @classmethod
+    def tearDownClass(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def test_stores_yum_proxy_from_composer_config(self):
+        self.assertEqual('https://proxy.example.com', self.yumconf.get('main', 'proxy'))
+
+    def test_disables_sslverify_if_composer_disables_it(self):
+        self.assertEqual('0', self.yumconf.get('main', 'sslverify'))
+
+    def test_sets_releasever_from_composer(self):
+        self.assertEqual('6', self.yb.conf.yumvar['releasever'])
+
+    def test_doesnt_use_system_repos(self):
+        # no other repos defined for this test
+        self.assertEqual({}, self.yb._repos.repos)
+
+
+class CreateYumDirsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # remove this directory
+        if os.path.exists('/var/tmp/composer/yum/root'):
+            shutil.rmtree('/var/tmp/composer/yum/root')
+
+    def test_creates_missing_yum_root_directory(self):
+        config = configure(test_config=True)
+
+        # will create the above directory if missing
+        _ = get_base_object(config)
+
+        self.assertTrue(os.path.exists('/var/tmp/composer/yum/root'))


### PR DESCRIPTION
- test against already existing git repository
- test commit_recipe_file() handling of IOError
- update tests for commit_recipe_directory()
  - add asserts on the existing test. Not raising an exception
    isn't enough!
  - add test which exercises the method under test while it handles
    exceptions raised by other methods
- test for list_commits() when the underlying calls fail to convert
  timestamp
- test for find_name() when `name' is not on the list
- tests for get_revision_from_tag()