### PR TITLE
add system-logos dependency for syslinux

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -50,7 +50,7 @@ installpkg glibc-all-langpacks
     installpkg shim-ia32 grub2-efi-ia32-cdboot
 %endif
 %if basearch in ("i386", "x86_64"):
-    installpkg biosdevname memtest86+ syslinux
+    installpkg biosdevname memtest86+ syslinux system-logos
     installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
 %endif
 %if basearch in ("ppc", "ppc64", "ppc64le"):


### PR DESCRIPTION
The x86.tmpl explicitly references the syslinux-splash provided in
the system-logos package and fails if it's not there so implicitly
install it on arches where syslinux is supported to ensure it's
there. Fixes rhbz #1529239

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>