### PR TITLE
Really don't try to build EFI images on i386

### DIFF
--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -76,7 +76,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %if exists("boot/efi/EFI/*/gcdx64.efi"):
     <% efiarch64 = 'X64' %>
 %endif
-%if efiarch32 or efiarch64 and basearch != 'i386':
+%if (efiarch32 or efiarch64) and basearch != 'i386':
     <%
     efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
     images = ["images/efiboot.img"]

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -78,7 +78,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %if exists("boot/efi/EFI/*/gcdx64.efi"):
     <% efiarch64 = 'X64' %>
 %endif
-%if efiarch32 or efiarch64 and basearch != 'i386':
+%if (efiarch32 or efiarch64) and basearch != 'i386':
     <%
     efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
     images = ["images/efiboot.img"]


### PR DESCRIPTION
The previous attempt to fix this failed because of operator
ordering, so we actually still tried to build EFI images on
i386, so i386 lives failed. This really fixes it. I tested. I
actually built a 32-bit live and it worked.

Signed-off-by: Adam Williamson <awilliam@redhat.com>