### PR TITLE
cleanup: don't remove libgstgl

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -351,7 +351,7 @@ runcmd chroot ${root} find -L /etc /usr -xdev -type l -and \! -name "mtab" \
 removefrom gstreamer1 --allbut /usr/${libdir}/libgstbase-1.0.* \
                                /usr/${libdir}/libgstreamer-1.0.*
 removefrom gstreamer1-plugins-base --allbut \
-        /usr/${libdir}/libgst{allocators,app,audio,badallocators,fft,pbutils,tag,video}-1.0.*
+        /usr/${libdir}/libgst{allocators,app,audio,badallocators,fft,gl,pbutils,tag,video}-1.0.*
 
 ## We have enough geoip libraries, thanks
 removepkg geoclue2


### PR DESCRIPTION
It looks like gnome-helper grep a dependency on it so let's not remove
it. From today's pungi run we can see this error in the verify:

```
libgstgl-1.0.so.0, needed by /usr/bin/gnome-help, not found
```